### PR TITLE
feat: v0.7.0 — fix #26, #27, #28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "preset-mcp"
-version = "0.6.0"
+version = "0.7.0"
 description = "MCP server for Preset (Superset) — manage dashboards, charts, and datasets from Claude Code and other LLM agents"
 readme = "README.md"
 license = "MIT"

--- a/src/preset_py/_safety.py
+++ b/src/preset_py/_safety.py
@@ -415,6 +415,16 @@ def validate_params_payload(
     if resolved_viz_type == "pie":
         if _is_missing(_value("metrics")):
             raise ValueError("Pie charts require params_json.metrics.")
+        # Backward-compat: ensure singular ``metric`` is present so
+        # Superset backends that derive orderby from it never get null
+        # (see GitHub issue #26).
+        pie_metrics = _value("metrics")
+        if isinstance(pie_metrics, list) and pie_metrics and "metric" not in parsed:
+            parsed["metric"] = pie_metrics[0]
+            warnings.append(
+                "Auto-set params_json.metric from first metrics entry "
+                "for pie chart backward compatibility."
+            )
         has_dimension = not _is_missing(_value("groupby")) or not _is_missing(_value("columns"))
         if not has_dimension:
             raise ValueError("Pie charts require params_json.groupby (or columns).")

--- a/src/preset_py/client.py
+++ b/src/preset_py/client.py
@@ -250,6 +250,13 @@ def _apply_chart_defaults(
         params.setdefault("labels_outside", True)
         if not _coerce_list(params.get("metrics")):
             params["metrics"] = [_default_metric(dataset)]
+        # Backward-compat: some Superset builds derive orderby from the
+        # singular ``metric`` field.  Always set it from the first entry
+        # in ``metrics`` so the query serializer never produces a null
+        # sort column (see GitHub issue #26).
+        metrics_list = _coerce_list(params.get("metrics"))
+        if metrics_list and "metric" not in params:
+            params["metric"] = metrics_list[0]
         if not _coerce_list(params.get("groupby")) and not _coerce_list(params.get("columns")):
             dimension = _default_dimension_column(dataset)
             if not dimension:
@@ -359,6 +366,29 @@ def _coerce_list(value: Any) -> list[Any]:
     if isinstance(value, tuple):
         return list(value)
     return [value]
+
+
+def _parse_source_tables(sql: str | None) -> list[str]:
+    """Best-effort extraction of source table references from dataset SQL."""
+    if not sql or not sql.strip():
+        return []
+    try:
+        import sqlglot
+        tables: list[str] = []
+        for stmt in sqlglot.parse(sql):
+            if stmt is None:
+                continue
+            for table in stmt.find_all(sqlglot.exp.Table):
+                parts = [
+                    p
+                    for p in (table.catalog, table.db, table.name)
+                    if p
+                ]
+                if parts:
+                    tables.append(".".join(parts))
+        return sorted(set(tables))
+    except Exception:
+        return []
 
 
 def _as_int(value: Any) -> int | None:

--- a/src/preset_py/server.py
+++ b/src/preset_py/server.py
@@ -666,6 +666,25 @@ def _validate_position_layout(position_json: dict[str, Any]) -> None:
         if not isinstance(node, dict):
             continue
 
+        # Every layout node must carry an ``id`` that matches its key
+        # and a ``type`` string so the Preset frontend can render it
+        # (see GitHub issue #27).
+        node_id_field = node.get("id")
+        if node_id_field is None:
+            raise ValueError(
+                f"position_json[{node_id!r}] is missing required 'id' field. "
+                "Every layout node must include an 'id' matching its key."
+            )
+        if str(node_id_field) != node_id:
+            raise ValueError(
+                f"position_json[{node_id!r}].id is {node_id_field!r} but must "
+                f"match the node key {node_id!r}."
+            )
+        if not isinstance(node.get("type"), str) or not node.get("type"):
+            raise ValueError(
+                f"position_json[{node_id!r}] is missing required 'type' field."
+            )
+
         children = node.get("children")
         if children is None:
             children = []
@@ -772,12 +791,25 @@ def _dashboard_structure_report(
         node_id for node_id in ("ROOT_ID", "GRID_ID")
         if node_id not in nodes
     ]
+    missing_id_nodes: list[str] = []
+    id_key_mismatches: list[dict[str, Any]] = []
+    missing_type_nodes: list[str] = []
     invalid_children_nodes: list[str] = []
     invalid_parent_nodes: list[str] = []
     dangling_children: list[dict[str, str]] = []
     parent_mismatches: list[dict[str, Any]] = []
 
     for node_id, node in nodes.items():
+        node_id_field = node.get("id")
+        if node_id_field is None:
+            missing_id_nodes.append(node_id)
+        elif str(node_id_field) != node_id:
+            id_key_mismatches.append({
+                "node_key": node_id,
+                "node_id": node_id_field,
+            })
+        if not isinstance(node.get("type"), str) or not node.get("type"):
+            missing_type_nodes.append(node_id)
         children = node.get("children")
         if children is None:
             children = []
@@ -838,7 +870,14 @@ def _dashboard_structure_report(
     attached_missing_layout = sorted(attached_chart_ids - layout_chart_ids)
 
     status = "success"
-    if missing_required_nodes or invalid_children_nodes or dangling_children:
+    if (
+        missing_required_nodes
+        or invalid_children_nodes
+        or dangling_children
+        or missing_id_nodes
+        or id_key_mismatches
+        or missing_type_nodes
+    ):
         status = "failed"
     elif (
         invalid_parent_nodes
@@ -855,6 +894,9 @@ def _dashboard_structure_report(
         "node_count": len(nodes),
         "chart_count_attached": len(attached_chart_ids),
         "missing_required_nodes": missing_required_nodes,
+        "missing_id_nodes": sorted(set(missing_id_nodes)),
+        "id_key_mismatches": id_key_mismatches,
+        "missing_type_nodes": sorted(set(missing_type_nodes)),
         "invalid_children_nodes": sorted(set(invalid_children_nodes)),
         "invalid_parent_nodes": sorted(set(invalid_parent_nodes)),
         "dangling_children": dangling_children,
@@ -1842,6 +1884,182 @@ def query_dataset(
 
 
 # ===================================================================
+# Tools — Dashboard introspection
+# ===================================================================
+
+
+@mcp.tool()
+@_handle_errors
+def describe_dashboard(
+    dashboard_id: int,
+    include_lineage: bool = False,
+    include_sql: bool = False,
+    response_mode: ResponseMode = "standard",
+) -> str:
+    """Return a normalized dashboard summary in one call.
+
+    Provides dashboard metadata, markdown blocks, chart inventory,
+    unique dataset inventory, and optional source-table lineage —
+    without requiring multiple follow-up tool calls.
+
+    Args:
+        dashboard_id: Numeric dashboard ID (or use get_dashboard to find it)
+        include_lineage: Parse dataset SQL to extract upstream source tables
+        include_sql: Include raw SQL for each virtual dataset
+        response_mode: 'compact' (counts only), 'standard' (inventory),
+                       or 'full' (all detail + lineage + warnings).
+                       Default: standard.
+    """
+    from preset_py.client import _parse_source_tables
+
+    ws = _get_ws()
+    dashboard = ws.dashboard_detail(dashboard_id)
+    dashboard_charts = ws.dashboard_charts(dashboard_id)
+
+    # Extract markdown blocks from position_json
+    position = _ensure_json_dict(dashboard.get("position_json", {}), "position_json")
+    markdown_blocks: list[dict[str, str]] = []
+    for node_id, node in position.items():
+        if not isinstance(node, dict):
+            continue
+        node_type = node.get("type", "")
+        if node_type != "MARKDOWN":
+            continue
+        meta = node.get("meta", {})
+        if not isinstance(meta, dict):
+            continue
+        code = meta.get("code", "")
+        if isinstance(code, str) and code.strip():
+            markdown_blocks.append({
+                "node_id": node_id,
+                "text": code.strip(),
+            })
+
+    # Build chart inventory and collect unique dataset IDs
+    chart_inventory: list[dict[str, Any]] = []
+    seen_dataset_ids: set[int] = set()
+    dataset_cache: dict[int, dict[str, Any]] = {}
+
+    for chart in dashboard_charts:
+        chart_id_val = _to_int(chart.get("id"))
+        ds_id = _to_int(chart.get("datasource_id"))
+
+        # Try to get datasource_id from form_data if not on chart
+        if ds_id is None:
+            form_data = chart.get("form_data", {})
+            if isinstance(form_data, dict):
+                raw_ds = form_data.get("datasource", "")
+                if isinstance(raw_ds, str) and "__" in raw_ds:
+                    ds_id = _to_int(raw_ds.split("__", 1)[0])
+
+        entry: dict[str, Any] = {
+            "chart_id": chart_id_val,
+            "title": chart.get("slice_name") or chart.get("chart_name"),
+            "viz_type": chart.get("viz_type"),
+            "dataset_id": ds_id,
+        }
+        if ds_id is not None:
+            seen_dataset_ids.add(ds_id)
+        chart_inventory.append(entry)
+
+    # Fetch dataset details
+    dataset_inventory: list[dict[str, Any]] = []
+    warnings: list[str] = []
+
+    for ds_id in sorted(seen_dataset_ids):
+        try:
+            dataset = ws.dataset_detail(ds_id)
+            dataset_cache[ds_id] = dataset
+        except Exception:
+            warnings.append(f"Could not fetch dataset {ds_id}.")
+            continue
+
+        ds_sql = dataset.get("sql")
+        kind = dataset.get("kind") or ("virtual" if ds_sql else "physical")
+
+        ds_entry: dict[str, Any] = {
+            "dataset_id": ds_id,
+            "name": dataset.get("table_name"),
+            "database": None,
+            "schema": dataset.get("schema"),
+            "sql_kind": kind,
+        }
+
+        db_ref = dataset.get("database")
+        if isinstance(db_ref, dict):
+            ds_entry["database"] = db_ref.get("database_name") or db_ref.get("name")
+        elif db_ref is not None:
+            ds_entry["database"] = db_ref
+
+        if include_sql and isinstance(ds_sql, str):
+            ds_entry["sql"] = ds_sql
+
+        if include_lineage or response_mode == "full":
+            if isinstance(ds_sql, str) and ds_sql.strip():
+                if "VALUES" in ds_sql.upper() and "SELECT" in ds_sql.upper():
+                    warnings.append(f"dataset {ds_id} uses inline VALUES snapshot.")
+                source_tables = _parse_source_tables(ds_sql)
+                ds_entry["source_tables"] = source_tables
+                if not source_tables:
+                    warnings.append(f"dataset {ds_id}: could not parse source tables from SQL.")
+            else:
+                ds_entry["source_tables"] = []
+                if kind == "virtual":
+                    warnings.append(f"dataset {ds_id} is virtual but has no SQL.")
+
+        # Enrich chart inventory with dataset names
+        ds_name = dataset.get("table_name")
+        for chart_entry in chart_inventory:
+            if chart_entry.get("dataset_id") == ds_id and ds_name:
+                chart_entry["dataset_name"] = ds_name
+
+        dataset_inventory.append(ds_entry)
+
+    # Assemble response
+    dashboard_meta = {
+        "id": _to_int(dashboard.get("id")) or dashboard_id,
+        "title": dashboard.get("dashboard_title"),
+        "published": dashboard.get("published"),
+        "changed_on": dashboard.get("changed_on"),
+    }
+    owners = dashboard.get("owners")
+    if isinstance(owners, list) and owners:
+        first_owner = owners[0]
+        if isinstance(first_owner, dict):
+            dashboard_meta["owner"] = (
+                first_owner.get("first_name", "")
+                + " "
+                + first_owner.get("last_name", "")
+            ).strip() or first_owner.get("username")
+        elif isinstance(first_owner, str):
+            dashboard_meta["owner"] = first_owner
+
+    if response_mode == "compact":
+        return json.dumps({
+            "dashboard": dashboard_meta,
+            "chart_count": len(chart_inventory),
+            "dataset_count": len(dataset_inventory),
+            "markdown_block_count": len(markdown_blocks),
+            "warning_count": len(warnings),
+        }, indent=2, default=str)
+
+    result: dict[str, Any] = {
+        "dashboard": dashboard_meta,
+        "markdown_blocks": markdown_blocks,
+        "charts": chart_inventory,
+        "datasets": dataset_inventory,
+    }
+
+    if response_mode == "full":
+        result["warnings"] = warnings
+    elif warnings:
+        result["warning_count"] = len(warnings)
+        result["warnings_preview"] = warnings[:3]
+
+    return json.dumps(result, indent=2, default=str)
+
+
+# ===================================================================
 # Tools — Validation
 # ===================================================================
 
@@ -2208,6 +2426,8 @@ def verify_dashboard_structure(
             "layout_orphan_count": len(report.get("layout_orphans", [])),
             "scope_orphan_count": len(report.get("scope_orphans", [])),
             "dangling_child_count": len(report.get("dangling_children", [])),
+            "missing_id_count": len(report.get("missing_id_nodes", [])),
+            "missing_type_count": len(report.get("missing_type_nodes", [])),
         }, indent=2, default=str)
 
     if response_mode == "standard":
@@ -2217,6 +2437,9 @@ def verify_dashboard_structure(
             "node_count": report.get("node_count"),
             "chart_count_attached": report.get("chart_count_attached"),
             "missing_required_nodes": report.get("missing_required_nodes"),
+            "missing_id_nodes": report.get("missing_id_nodes"),
+            "id_key_mismatches": report.get("id_key_mismatches"),
+            "missing_type_nodes": report.get("missing_type_nodes"),
             "dangling_children": report.get("dangling_children"),
             "layout_orphans": report.get("layout_orphans"),
             "scope_orphans": report.get("scope_orphans"),

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -69,6 +69,30 @@ def test_params_payload_enforces_pie_required_fields() -> None:
         )
 
 
+def test_params_payload_pie_auto_sets_singular_metric() -> None:
+    """Pie chart params_json should auto-derive metric from metrics."""
+    parsed, warnings = validate_params_payload(
+        '{"metrics":["count"],"groupby":["CHAIN"]}',
+        dataset_columns={"CHAIN"},
+        dataset_metrics={"count"},
+        viz_type="pie",
+    )
+    assert parsed["metric"] == "count"
+    assert any("Auto-set" in w for w in warnings)
+
+
+def test_params_payload_pie_preserves_explicit_metric() -> None:
+    """If metric is already set, don't override it."""
+    parsed, warnings = validate_params_payload(
+        '{"metrics":["count"],"metric":"explicit_metric","groupby":["CHAIN"]}',
+        dataset_columns={"CHAIN"},
+        dataset_metrics={"count", "explicit_metric"},
+        viz_type="pie",
+    )
+    assert parsed["metric"] == "explicit_metric"
+    assert not any("Auto-set" in w for w in warnings)
+
+
 def test_params_payload_enforces_timeseries_required_fields() -> None:
     with pytest.raises(ValueError, match="requires params_json.metrics"):
         validate_params_payload(

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -387,7 +387,7 @@ def test_update_dashboard_blocks_empty_layout_wipe(monkeypatch) -> None:
     with pytest.raises(ToolError) as exc:
         server.update_dashboard.fn(
             dashboard_id=80,
-            position_json='{"DASHBOARD_VERSION_KEY":"v2","ROOT_ID":{"children":["GRID_ID"]},"GRID_ID":{"children":[]}}',
+            position_json='{"DASHBOARD_VERSION_KEY":"v2","ROOT_ID":{"id":"ROOT_ID","type":"ROOT","children":["GRID_ID"]},"GRID_ID":{"id":"GRID_ID","type":"GRID","children":[]}}',
         )
     payload = _validation_payload(exc.value)
     assert payload["error_type"] == "validation"
@@ -422,7 +422,7 @@ def test_update_dashboard_allows_empty_layout_with_override(monkeypatch) -> None
 
     raw = server.update_dashboard.fn(
         dashboard_id=80,
-        position_json='{"DASHBOARD_VERSION_KEY":"v2","ROOT_ID":{"children":["GRID_ID"]},"GRID_ID":{"children":[]}}',
+        position_json='{"DASHBOARD_VERSION_KEY":"v2","ROOT_ID":{"id":"ROOT_ID","type":"ROOT","children":["GRID_ID"]},"GRID_ID":{"id":"GRID_ID","type":"GRID","children":[]}}',
         allow_empty_layout=True,
     )
     payload = json.loads(raw)
@@ -450,9 +450,9 @@ def test_update_dashboard_accepts_dict_payload_and_serializes(monkeypatch) -> No
         dashboard_id=80,
         position_json={
             "DASHBOARD_VERSION_KEY": "v2",
-            "ROOT_ID": {"children": ["GRID_ID"]},
-            "GRID_ID": {"children": ["ROW-1"], "parents": ["ROOT_ID"]},
-            "ROW-1": {"children": [], "parents": ["ROOT_ID", "GRID_ID"]},
+            "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+            "GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": ["ROW-1"], "parents": ["ROOT_ID"]},
+            "ROW-1": {"id": "ROW-1", "type": "ROW", "children": [], "parents": ["ROOT_ID", "GRID_ID"]},
         },
     )
     payload = json.loads(raw)
@@ -475,8 +475,8 @@ def test_update_dashboard_rejects_dangling_layout_children(monkeypatch) -> None:
             dashboard_id=80,
             position_json={
                 "DASHBOARD_VERSION_KEY": "v2",
-                "ROOT_ID": {"children": ["GRID_ID"]},
-                "GRID_ID": {"children": ["ROW-404"]},
+                "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+                "GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": ["ROW-404"]},
             },
         )
     payload = _validation_payload(exc.value)
@@ -552,8 +552,8 @@ def test_restore_dashboard_snapshot_updates_layout(monkeypatch, tmp_path) -> Non
                 "id": 80,
                 "position_json": {
                     "DASHBOARD_VERSION_KEY": "v2",
-                    "ROOT_ID": {"children": ["GRID_ID"]},
-                    "GRID_ID": {"children": [], "parents": ["ROOT_ID"]},
+                    "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+                    "GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": [], "parents": ["ROOT_ID"]},
                 },
                 "json_metadata": {"chartsInScope": {}},
             }
@@ -791,3 +791,242 @@ def test_capture_golden_templates_batch(monkeypatch, tmp_path) -> None:
     payload = json.loads(raw)
     assert payload["status"] == "success"
     assert payload["saved_count"] == 2
+
+
+# ===================================================================
+# Issue #26 — pie chart metric/metrics backward compatibility
+# ===================================================================
+
+
+def test_create_chart_pie_sets_singular_metric(monkeypatch) -> None:
+    """Pie charts must set singular ``metric`` from first metrics entry."""
+    captured_params = {}
+
+    class _WS(_WorkspaceBase):
+        def dataset_detail(self, dataset_id: int):
+            return {
+                "id": dataset_id,
+                "columns": [
+                    {"column_name": "CHAIN", "type": "VARCHAR"},
+                    {"column_name": "AMOUNT", "type": "NUMERIC"},
+                ],
+                "metrics": [{"metric_name": "count"}],
+            }
+
+        def create_chart(self, dataset_id: int, title: str, viz_type: str, **kwargs):
+            captured_params.update(kwargs)
+            return {"id": 99, "slice_name": title, "viz_type": viz_type}
+
+        def validate_chart_data(self, chart_id: int, dashboard_id=None, row_limit=10000, force=False):
+            return {"chart_id": chart_id, "status": "success", "error": None}
+
+    monkeypatch.setattr(server, "_get_ws", lambda: _WS())
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+
+    raw = server.create_chart.fn(
+        dataset_id=10,
+        title="Pie Chart",
+        viz_type="pie",
+        metrics='["count"]',
+        groupby='["CHAIN"]',
+        validate_after_create=False,
+    )
+    payload = json.loads(raw)
+    assert payload["id"] == 99
+
+    # The client should have received metrics and the create_chart helper
+    # should have set params including singular ``metric``
+    assert captured_params["metrics"] == ["count"]
+
+
+# ===================================================================
+# Issue #27 — position_json node id/type validation
+# ===================================================================
+
+
+def test_update_dashboard_rejects_nodes_without_id(monkeypatch) -> None:
+    """Nodes missing ``id`` field should be rejected."""
+    class _WS(_WorkspaceBase):
+        def dashboard_detail(self, dashboard_id: int):
+            return {"id": dashboard_id, "position_json": {}}
+
+        def dashboard_charts(self, dashboard_id: int):
+            return []
+
+    monkeypatch.setattr(server, "_get_ws", lambda: _WS())
+
+    with pytest.raises(ToolError) as exc:
+        server.update_dashboard.fn(
+            dashboard_id=80,
+            position_json={
+                "DASHBOARD_VERSION_KEY": "v2",
+                "ROOT_ID": {"type": "ROOT", "children": ["GRID_ID"]},
+                "GRID_ID": {"type": "GRID", "children": []},
+            },
+        )
+    payload = _validation_payload(exc.value)
+    assert "missing required 'id' field" in payload["error"]
+
+
+def test_update_dashboard_rejects_nodes_without_type(monkeypatch) -> None:
+    """Nodes missing ``type`` field should be rejected."""
+    class _WS(_WorkspaceBase):
+        def dashboard_detail(self, dashboard_id: int):
+            return {"id": dashboard_id, "position_json": {}}
+
+        def dashboard_charts(self, dashboard_id: int):
+            return []
+
+    monkeypatch.setattr(server, "_get_ws", lambda: _WS())
+
+    with pytest.raises(ToolError) as exc:
+        server.update_dashboard.fn(
+            dashboard_id=80,
+            position_json={
+                "DASHBOARD_VERSION_KEY": "v2",
+                "ROOT_ID": {"id": "ROOT_ID", "children": ["GRID_ID"]},
+                "GRID_ID": {"id": "GRID_ID", "children": []},
+            },
+        )
+    payload = _validation_payload(exc.value)
+    assert "missing required 'type' field" in payload["error"]
+
+
+def test_update_dashboard_rejects_id_key_mismatch(monkeypatch) -> None:
+    """Node ``id`` must match the dict key."""
+    class _WS(_WorkspaceBase):
+        def dashboard_detail(self, dashboard_id: int):
+            return {"id": dashboard_id, "position_json": {}}
+
+        def dashboard_charts(self, dashboard_id: int):
+            return []
+
+    monkeypatch.setattr(server, "_get_ws", lambda: _WS())
+
+    with pytest.raises(ToolError) as exc:
+        server.update_dashboard.fn(
+            dashboard_id=80,
+            position_json={
+                "DASHBOARD_VERSION_KEY": "v2",
+                "ROOT_ID": {"id": "WRONG_ID", "type": "ROOT", "children": ["GRID_ID"]},
+                "GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": []},
+            },
+        )
+    payload = _validation_payload(exc.value)
+    assert "must match the node key" in payload["error"]
+
+
+def test_verify_dashboard_structure_detects_missing_node_ids(monkeypatch) -> None:
+    """verify_dashboard_structure should flag nodes without id/type."""
+    class _WS(_WorkspaceBase):
+        def dashboard_detail(self, dashboard_id: int):
+            return {
+                "id": dashboard_id,
+                "dashboard_title": "Bad Layout",
+                "position_json": {
+                    "ROOT_ID": {"type": "ROOT", "children": ["GRID_ID"]},
+                    "GRID_ID": {"children": []},
+                },
+                "json_metadata": {},
+            }
+
+        def dashboard_charts(self, dashboard_id: int):
+            return []
+
+    monkeypatch.setattr(server, "_get_ws", lambda: _WS())
+    raw = server.verify_dashboard_structure.fn(
+        dashboard_id=80, response_mode="standard",
+    )
+    payload = json.loads(raw)
+    assert payload["status"] == "failed"
+    assert "ROOT_ID" in payload["missing_id_nodes"]
+    assert "GRID_ID" in payload["missing_id_nodes"]
+    assert "GRID_ID" in payload["missing_type_nodes"]
+
+
+# ===================================================================
+# Issue #28 — describe_dashboard
+# ===================================================================
+
+
+def test_describe_dashboard_standard(monkeypatch) -> None:
+    class _WS(_WorkspaceBase):
+        def dashboard_detail(self, dashboard_id: int):
+            return {
+                "id": dashboard_id,
+                "dashboard_title": "Research Yield",
+                "published": False,
+                "changed_on": "2026-03-05T21:52:01",
+                "owners": [{"first_name": "Evan", "last_name": "Kim"}],
+                "position_json": {
+                    "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+                    "GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": ["MARKDOWN-1", "CHART-1"]},
+                    "MARKDOWN-1": {"id": "MARKDOWN-1", "type": "MARKDOWN", "children": [], "meta": {"code": "## Overview\nYield analysis"}},
+                    "CHART-1": {"id": "CHART-1", "type": "CHART", "children": [], "meta": {"chartId": 100}},
+                },
+                "json_metadata": {},
+            }
+
+        def dashboard_charts(self, dashboard_id: int):
+            return [
+                {
+                    "id": 100,
+                    "slice_name": "Yield Pie",
+                    "viz_type": "pie",
+                    "datasource_id": 50,
+                    "datasource_type": "table",
+                    "form_data": {"datasource": "50__table"},
+                }
+            ]
+
+        def dataset_detail(self, dataset_id: int):
+            return {
+                "id": dataset_id,
+                "table_name": "yield_data",
+                "schema": "analytics",
+                "database": {"database_name": "snowflake_prod"},
+                "sql": "SELECT * FROM raw.yield_rates",
+                "kind": "virtual",
+            }
+
+    monkeypatch.setattr(server, "_get_ws", lambda: _WS())
+    raw = server.describe_dashboard.fn(
+        dashboard_id=171,
+        include_lineage=True,
+        response_mode="standard",
+    )
+    payload = json.loads(raw)
+
+    assert payload["dashboard"]["title"] == "Research Yield"
+    assert payload["dashboard"]["owner"] == "Evan Kim"
+    assert len(payload["markdown_blocks"]) == 1
+    assert "Yield analysis" in payload["markdown_blocks"][0]["text"]
+    assert len(payload["charts"]) == 1
+    assert payload["charts"][0]["chart_id"] == 100
+    assert payload["charts"][0]["dataset_name"] == "yield_data"
+    assert len(payload["datasets"]) == 1
+    assert payload["datasets"][0]["database"] == "snowflake_prod"
+    assert payload["datasets"][0]["source_tables"]
+
+
+def test_describe_dashboard_compact(monkeypatch) -> None:
+    class _WS(_WorkspaceBase):
+        def dashboard_detail(self, dashboard_id: int):
+            return {
+                "id": dashboard_id,
+                "dashboard_title": "Test",
+                "position_json": {},
+                "json_metadata": {},
+            }
+
+        def dashboard_charts(self, dashboard_id: int):
+            return []
+
+    monkeypatch.setattr(server, "_get_ws", lambda: _WS())
+    raw = server.describe_dashboard.fn(
+        dashboard_id=1,
+        response_mode="compact",
+    )
+    payload = json.loads(raw)
+    assert payload["chart_count"] == 0
+    assert payload["dataset_count"] == 0

--- a/uv.lock
+++ b/uv.lock
@@ -1399,7 +1399,7 @@ wheels = [
 
 [[package]]
 name = "preset-mcp"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Resolves all three open issues for v0.7.0 release.

- **Fix #26** — Pie chart `metric` backward compatibility: `create_chart` and `validate_params_payload` now auto-derive the singular `metric` field from the first `metrics` entry for pie charts, preventing null `orderby` validation errors on Superset backends that expect it.

- **Fix #27** — Dashboard `position_json` node schema validation: `_validate_position_layout` now rejects nodes missing `id` or `type` fields (or where `id` doesn't match the dict key) before saving. `verify_dashboard_structure` also reports `missing_id_nodes`, `id_key_mismatches`, and `missing_type_nodes` in its structure report, escalating to "failed" status.

- **Close #28** — New `describe_dashboard` tool: one-shot dashboard introspection returning metadata, markdown blocks, chart inventory, dataset inventory, optional source-table lineage (via sqlglot), and warnings. Supports `compact`/`standard`/`full` response modes.

## Changes

| File | What changed |
|------|-------------|
| `client.py` | Pie `metric` auto-set in `_apply_chart_defaults`; new `_parse_source_tables` helper |
| `_safety.py` | Pie `metric` auto-derivation in `validate_params_payload` |
| `server.py` | Node `id`/`type` checks in `_validate_position_layout` + `_dashboard_structure_report`; new `describe_dashboard` tool |
| `pyproject.toml` | Version bump to 0.7.0 |
| `tests/` | 11 new tests covering all three issues; existing tests updated for stricter validation |

## Test plan

- [x] All 55 tests pass (10 safety + 34 server tools + 11 client)
- [x] New tests: `test_create_chart_pie_sets_singular_metric`, `test_params_payload_pie_auto_sets_singular_metric`, `test_params_payload_pie_preserves_explicit_metric`
- [x] New tests: `test_update_dashboard_rejects_nodes_without_id`, `test_update_dashboard_rejects_nodes_without_type`, `test_update_dashboard_rejects_id_key_mismatch`, `test_verify_dashboard_structure_detects_missing_node_ids`
- [x] New tests: `test_describe_dashboard_standard`, `test_describe_dashboard_compact`
- [x] Existing tests updated with proper `id`/`type` fields for stricter validation