### PR TITLE
Fix update_chart datasource binding loss and create_chart validation timeout (#30)

### DIFF
--- a/src/preset_py/server.py
+++ b/src/preset_py/server.py
@@ -2950,10 +2950,20 @@ def create_chart(
 
     if validate_after_create:
         dashboard_id = dashboards_list[0] if dashboards_list else None
-        payload["_validation"] = ws.validate_chart_data(
-            chart_id,
-            dashboard_id=dashboard_id,
-        )
+        try:
+            payload["_validation"] = ws.validate_chart_data(
+                chart_id,
+                dashboard_id=dashboard_id,
+            )
+        except Exception as exc:
+            payload["_validation"] = {
+                "chart_id": chart_id,
+                "status": "timeout",
+                "error": (
+                    f"Post-creation validation failed ({type(exc).__name__}: {exc}). "
+                    "The chart was created successfully — use get_chart to verify."
+                ),
+            }
     return json.dumps(payload, indent=2, default=str)
 
 
@@ -3127,6 +3137,19 @@ def update_chart(
                 "be a complete viz-compatible params payload, not a partial patch."
             ) from exc
 
+    # Preserve datasource binding: inject existing datasource/viz_type
+    # keys into the new params so the chart remains valid after update.
+    if params_json is not None:
+        existing_params = _ensure_json_dict(before.get("params", {}), "chart params") if before.get("params") else {}
+        new_params = json.loads(params_json)
+        if isinstance(new_params, dict):
+            if "datasource" not in new_params and "datasource" in existing_params:
+                new_params["datasource"] = existing_params["datasource"]
+            resolved = viz_type or before.get("viz_type")
+            if "viz_type" not in new_params and resolved:
+                new_params["viz_type"] = resolved
+            params_json = json.dumps(new_params)
+
     kwargs: dict[str, Any] = {}
     if title is not None:
         kwargs["slice_name"] = title
@@ -3161,10 +3184,20 @@ def update_chart(
 
     if validate_after_update:
         dashboard_id = dashboards_list[0] if dashboards_list else None
-        payload["_validation"] = ws.validate_chart_data(
-            chart_id,
-            dashboard_id=dashboard_id,
-        )
+        try:
+            payload["_validation"] = ws.validate_chart_data(
+                chart_id,
+                dashboard_id=dashboard_id,
+            )
+        except Exception as exc:
+            payload["_validation"] = {
+                "chart_id": chart_id,
+                "status": "timeout",
+                "error": (
+                    f"Post-update validation failed ({type(exc).__name__}: {exc}). "
+                    "The chart was updated successfully — use get_chart to verify."
+                ),
+            }
     return json.dumps(payload, indent=2, default=str)
 
 

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -1030,3 +1030,177 @@ def test_describe_dashboard_compact(monkeypatch) -> None:
     payload = json.loads(raw)
     assert payload["chart_count"] == 0
     assert payload["dataset_count"] == 0
+
+
+# ===================================================================
+# Issue #30 — update_chart preserves datasource; create_chart timeout
+# ===================================================================
+
+
+def test_update_chart_preserves_datasource_binding(monkeypatch) -> None:
+    """update_chart should inject existing datasource key into new params."""
+    captured_kwargs: dict = {}
+
+    class _WS(_WorkspaceBase):
+        def chart_detail(self, chart_id: int):
+            return {
+                "id": chart_id,
+                "viz_type": "pie",
+                "datasource_id": 42,
+                "params": json.dumps({
+                    "datasource": "42__table",
+                    "viz_type": "pie",
+                    "metrics": ["count"],
+                    "groupby": ["CHAIN"],
+                }),
+            }
+
+        def get_resource(self, resource_type: str, resource_id: int):
+            return self.chart_detail(resource_id)
+
+        def dataset_detail(self, dataset_id: int):
+            return {
+                "id": dataset_id,
+                "columns": [{"column_name": "CHAIN"}],
+                "metrics": [{"metric_name": "count"}],
+            }
+
+        def update_chart(self, chart_id: int, **kwargs):
+            captured_kwargs.update(kwargs)
+            return {"id": chart_id, "result": "ok"}
+
+    monkeypatch.setattr(server, "_get_ws", lambda: _WS())
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+
+    server.update_chart.fn(
+        chart_id=1,
+        params_json=json.dumps({
+            "metrics": ["count"],
+            "groupby": ["CHAIN"],
+        }),
+        validate_after_update=False,
+    )
+
+    updated_params = json.loads(captured_kwargs["params"])
+    assert updated_params["datasource"] == "42__table"
+    assert updated_params["viz_type"] == "pie"
+
+
+def test_update_chart_does_not_overwrite_user_datasource(monkeypatch) -> None:
+    """If user explicitly provides datasource in params_json, keep it."""
+    captured_kwargs: dict = {}
+
+    class _WS(_WorkspaceBase):
+        def chart_detail(self, chart_id: int):
+            return {
+                "id": chart_id,
+                "viz_type": "pie",
+                "datasource_id": 42,
+                "params": json.dumps({
+                    "datasource": "42__table",
+                    "viz_type": "pie",
+                    "metrics": ["count"],
+                    "groupby": ["CHAIN"],
+                }),
+            }
+
+        def get_resource(self, resource_type: str, resource_id: int):
+            return self.chart_detail(resource_id)
+
+        def dataset_detail(self, dataset_id: int):
+            return {
+                "id": dataset_id,
+                "columns": [{"column_name": "CHAIN"}],
+                "metrics": [{"metric_name": "count"}],
+            }
+
+        def update_chart(self, chart_id: int, **kwargs):
+            captured_kwargs.update(kwargs)
+            return {"id": chart_id, "result": "ok"}
+
+    monkeypatch.setattr(server, "_get_ws", lambda: _WS())
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+
+    server.update_chart.fn(
+        chart_id=1,
+        params_json=json.dumps({
+            "datasource": "42__table",
+            "metrics": ["count"],
+            "groupby": ["CHAIN"],
+        }),
+        validate_after_update=False,
+    )
+
+    updated_params = json.loads(captured_kwargs["params"])
+    assert updated_params["datasource"] == "42__table"
+
+
+def test_create_chart_returns_id_on_validation_timeout(monkeypatch) -> None:
+    """create_chart should return chart ID even if post-validation times out."""
+
+    class _WS(_WorkspaceBase):
+        def dataset_detail(self, dataset_id: int):
+            return {
+                "id": dataset_id,
+                "columns": [
+                    {"column_name": "CHAIN", "type": "VARCHAR"},
+                    {"column_name": "AMOUNT", "type": "NUMERIC"},
+                ],
+                "metrics": [{"metric_name": "count"}],
+            }
+
+        def create_chart(self, dataset_id: int, title: str, viz_type: str, **kwargs):
+            return {"id": 77, "slice_name": title, "viz_type": viz_type}
+
+        def validate_chart_data(self, chart_id: int, **kwargs):
+            raise TimeoutError("Connection timed out after 120s")
+
+    monkeypatch.setattr(server, "_get_ws", lambda: _WS())
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+
+    raw = server.create_chart.fn(
+        dataset_id=10,
+        title="Test Chart",
+        viz_type="table",
+        metrics='["count"]',
+        groupby='["CHAIN"]',
+        validate_after_create=True,
+    )
+    payload = json.loads(raw)
+    assert payload["id"] == 77
+    assert payload["_validation"]["status"] == "timeout"
+    assert "created successfully" in payload["_validation"]["error"]
+
+
+def test_update_chart_returns_result_on_validation_timeout(monkeypatch) -> None:
+    """update_chart should return result even if post-validation times out."""
+
+    class _WS(_WorkspaceBase):
+        def chart_detail(self, chart_id: int):
+            return {
+                "id": chart_id,
+                "viz_type": "table",
+                "datasource_id": 10,
+                "params": json.dumps({"datasource": "10__table"}),
+            }
+
+        def get_resource(self, resource_type: str, resource_id: int):
+            return self.chart_detail(resource_id)
+
+        def update_chart(self, chart_id: int, **kwargs):
+            return {"id": chart_id, "result": "ok"}
+
+        def validate_chart_data(self, chart_id: int, **kwargs):
+            raise TimeoutError("Connection timed out after 120s")
+
+    monkeypatch.setattr(server, "_get_ws", lambda: _WS())
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+
+    raw = server.update_chart.fn(
+        chart_id=1,
+        title="New Title",
+        validate_after_update=True,
+    )
+    payload = json.loads(raw)
+    assert payload["_validation"]["status"] == "timeout"
+    assert "updated successfully" in payload["_validation"]["error"]


### PR DESCRIPTION
- Preserve existing datasource and viz_type keys in params when
  update_chart receives a new params_json payload, preventing
  validation failures from stripped datasource metadata
- Catch exceptions during post-create/post-update chart-data validation
  so the chart ID is always returned even when validation times out
- Add tests for both fixes

https://claude.ai/code/session_016Jys9AX548UgykrSTtvQ1v