### PR TITLE
Fix dashboard recovery layout verification and snapshot portability

### DIFF
--- a/src/preset_py/server.py
+++ b/src/preset_py/server.py
@@ -29,6 +29,7 @@ import os
 import re
 import sys
 import time
+from collections import deque
 from datetime import datetime, timezone
 from difflib import get_close_matches
 from collections.abc import Callable
@@ -657,6 +658,232 @@ def _extract_position_chart_refs(position_json: Any) -> dict[str, int]:
     return refs
 
 
+_LAYOUT_WRAPPER_TYPES = frozenset({"ROW", "COLUMN", "TAB", "TABS"})
+
+
+def _find_duplicate_chart_placements(position_json: Any) -> list[dict[str, Any]]:
+    """Return duplicate chart placements keyed by chart_id."""
+    refs = _extract_position_chart_refs(position_json)
+    chart_to_nodes: dict[int, list[str]] = {}
+    for node_id, chart_id in refs.items():
+        chart_to_nodes.setdefault(chart_id, []).append(node_id)
+    return [
+        {"chart_id": chart_id, "layout_nodes": sorted(node_ids)}
+        for chart_id, node_ids in sorted(chart_to_nodes.items())
+        if len(node_ids) > 1
+    ]
+
+
+def _reachable_layout_node_ids(position_json: Any) -> set[str]:
+    payload = _ensure_json_dict(position_json, "position_json")
+    nodes = {
+        str(node_id): node
+        for node_id, node in payload.items()
+        if isinstance(node, dict)
+    }
+    queue: deque[str] = deque(["ROOT_ID"] if "ROOT_ID" in nodes else [])
+    reachable: set[str] = set()
+    while queue:
+        current = queue.popleft()
+        if current in reachable:
+            continue
+        reachable.add(current)
+        children = nodes.get(current, {}).get("children")
+        if not isinstance(children, list):
+            continue
+        for child in children:
+            child_id = str(child)
+            if child_id in nodes and child_id not in reachable:
+                queue.append(child_id)
+    return reachable
+
+
+def _layout_preorder_index(position_json: Any) -> dict[str, int]:
+    payload = _ensure_json_dict(position_json, "position_json")
+    nodes = {
+        str(node_id): node
+        for node_id, node in payload.items()
+        if isinstance(node, dict)
+    }
+    order: dict[str, int] = {}
+    stack: list[str] = ["ROOT_ID"] if "ROOT_ID" in nodes else []
+    while stack:
+        current = stack.pop()
+        if current in order:
+            continue
+        order[current] = len(order)
+        children = nodes.get(current, {}).get("children")
+        if not isinstance(children, list):
+            continue
+        for child in reversed(children):
+            child_id = str(child)
+            if child_id in nodes and child_id not in order:
+                stack.append(child_id)
+    for node_id in sorted(nodes):
+        if node_id not in order:
+            order[node_id] = len(order)
+    return order
+
+
+def _layout_descendant_chart_ids(position_json: Any) -> dict[str, tuple[int, ...]]:
+    payload = _ensure_json_dict(position_json, "position_json")
+    nodes = {
+        str(node_id): node
+        for node_id, node in payload.items()
+        if isinstance(node, dict)
+    }
+    chart_refs = _extract_position_chart_refs(payload)
+    cache: dict[str, tuple[int, ...]] = {}
+    visiting: set[str] = set()
+
+    def collect(node_id: str) -> tuple[int, ...]:
+        if node_id in cache:
+            return cache[node_id]
+        if node_id in visiting:
+            return tuple()
+        visiting.add(node_id)
+        if node_id in chart_refs:
+            result = (chart_refs[node_id],)
+        else:
+            charts: list[int] = []
+            children = nodes.get(node_id, {}).get("children")
+            if isinstance(children, list):
+                for child in children:
+                    child_id = str(child)
+                    if child_id in nodes:
+                        charts.extend(collect(child_id))
+            result = tuple(charts)
+        visiting.remove(node_id)
+        cache[node_id] = result
+        return result
+
+    for node_id in nodes:
+        collect(node_id)
+    return cache
+
+
+def _remove_layout_nodes(
+    position_json: dict[str, Any],
+    nodes_to_remove: set[str],
+) -> dict[str, Any]:
+    if not nodes_to_remove:
+        return position_json
+
+    cleaned: dict[str, Any] = {}
+    for node_id, node in position_json.items():
+        node_key = str(node_id)
+        if isinstance(node, dict) and node_key in nodes_to_remove:
+            continue
+        if isinstance(node, dict):
+            updated = dict(node)
+            children = node.get("children")
+            if isinstance(children, list):
+                updated["children"] = [
+                    child for child in children
+                    if str(child) not in nodes_to_remove
+                ]
+            parents = node.get("parents")
+            if isinstance(parents, list):
+                updated["parents"] = [
+                    parent for parent in parents
+                    if str(parent) not in nodes_to_remove
+                ]
+            cleaned[node_id] = updated
+        else:
+            cleaned[node_id] = node
+    return cleaned
+
+
+def _prune_unreachable_layout_nodes(position_json: dict[str, Any]) -> dict[str, Any]:
+    reachable = _reachable_layout_node_ids(position_json)
+    if not reachable:
+        return position_json
+    nodes_to_remove = {
+        str(node_id)
+        for node_id, node in position_json.items()
+        if isinstance(node, dict) and str(node_id) not in reachable
+    }
+    return _remove_layout_nodes(position_json, nodes_to_remove)
+
+
+def _prune_empty_layout_wrappers(position_json: dict[str, Any]) -> dict[str, Any]:
+    cleaned = position_json
+    while True:
+        empty_wrappers: set[str] = set()
+        for node_id, node in cleaned.items():
+            if not isinstance(node, dict):
+                continue
+            node_key = str(node_id)
+            if node_key in ("ROOT_ID", "GRID_ID"):
+                continue
+            if str(node.get("type", "")) not in _LAYOUT_WRAPPER_TYPES:
+                continue
+            children = node.get("children")
+            if children is None:
+                children = []
+            if isinstance(children, list) and not children:
+                empty_wrappers.add(node_key)
+        if not empty_wrappers:
+            return cleaned
+        cleaned = _remove_layout_nodes(cleaned, empty_wrappers)
+        cleaned = _prune_unreachable_layout_nodes(cleaned)
+
+
+def _deduplicate_layout_containers(position_json: dict[str, Any]) -> dict[str, Any]:
+    """Remove duplicate layout subtrees while preserving the first visible copy."""
+    if not position_json:
+        return position_json
+
+    cleaned = dict(position_json)
+    reachable = _reachable_layout_node_ids(cleaned)
+    preorder = _layout_preorder_index(cleaned)
+    descendant_charts = _layout_descendant_chart_ids(cleaned)
+    chart_nodes = _extract_position_chart_refs(cleaned)
+
+    duplicate_wrappers: dict[tuple[str, tuple[int, ...]], list[str]] = {}
+    for node_id in reachable:
+        node = cleaned.get(node_id)
+        if not isinstance(node, dict):
+            continue
+        if node_id in ("ROOT_ID", "GRID_ID") or node_id in chart_nodes:
+            continue
+        node_type = str(node.get("type", ""))
+        if node_type not in _LAYOUT_WRAPPER_TYPES:
+            continue
+        signature = descendant_charts.get(node_id, tuple())
+        if not signature:
+            continue
+        duplicate_wrappers.setdefault((node_type, signature), []).append(node_id)
+
+    wrapper_nodes_to_remove: set[str] = set()
+    for node_ids in duplicate_wrappers.values():
+        if len(node_ids) <= 1:
+            continue
+        ordered = sorted(node_ids, key=lambda node_id: preorder.get(node_id, len(preorder)))
+        wrapper_nodes_to_remove.update(ordered[1:])
+
+    if wrapper_nodes_to_remove:
+        cleaned = _remove_layout_nodes(cleaned, wrapper_nodes_to_remove)
+        cleaned = _prune_unreachable_layout_nodes(cleaned)
+        cleaned = _prune_empty_layout_wrappers(cleaned)
+
+    duplicate_chart_nodes: set[str] = set()
+    preorder = _layout_preorder_index(cleaned)
+    for duplicate in _find_duplicate_chart_placements(cleaned):
+        ordered = sorted(
+            duplicate["layout_nodes"],
+            key=lambda node_id: preorder.get(node_id, len(preorder)),
+        )
+        duplicate_chart_nodes.update(ordered[1:])
+
+    if duplicate_chart_nodes:
+        cleaned = _remove_layout_nodes(cleaned, duplicate_chart_nodes)
+        cleaned = _prune_unreachable_layout_nodes(cleaned)
+        cleaned = _prune_empty_layout_wrappers(cleaned)
+
+    return cleaned
+
+
 def _extract_scope_chart_refs(json_metadata: Any) -> set[int]:
     payload = _ensure_json_dict(json_metadata, "json_metadata")
     charts_in_scope = payload.get("chartsInScope")
@@ -893,20 +1120,7 @@ def _dashboard_structure_report(
                         "child_parents": sorted(normalized_parents),
                     })
 
-    reachable: set[str] = set()
-    queue: list[str] = ["ROOT_ID"] if "ROOT_ID" in nodes else []
-    while queue:
-        current = queue.pop(0)
-        if current in reachable:
-            continue
-        reachable.add(current)
-        children = nodes.get(current, {}).get("children")
-        if not isinstance(children, list):
-            continue
-        for child in children:
-            child_id = str(child)
-            if child_id in nodes and child_id not in reachable:
-                queue.append(child_id)
+    reachable = _reachable_layout_node_ids(position)
 
     unreachable_nodes = sorted(
         node_id for node_id in nodes.keys()
@@ -920,6 +1134,7 @@ def _dashboard_structure_report(
     }
     layout_chart_ids = set(_extract_position_chart_refs(position).values())
     scope_chart_ids = _extract_scope_chart_refs(metadata)
+    duplicate_chart_placements = _find_duplicate_chart_placements(position)
 
     layout_orphans = sorted(layout_chart_ids - attached_chart_ids)
     scope_orphans = sorted(scope_chart_ids - attached_chart_ids)
@@ -942,6 +1157,7 @@ def _dashboard_structure_report(
         or layout_orphans
         or scope_orphans
         or attached_missing_layout
+        or duplicate_chart_placements
     ):
         status = "warning"
 
@@ -963,6 +1179,7 @@ def _dashboard_structure_report(
         "layout_orphans": layout_orphans,
         "scope_orphans": scope_orphans,
         "attached_missing_layout": attached_missing_layout,
+        "duplicate_chart_placements": duplicate_chart_placements,
     }
 
 
@@ -2484,6 +2701,7 @@ def verify_dashboard_structure(
             "dangling_child_count": len(report.get("dangling_children", [])),
             "missing_id_count": len(report.get("missing_id_nodes", [])),
             "missing_type_count": len(report.get("missing_type_nodes", [])),
+            "duplicate_chart_count": len(report.get("duplicate_chart_placements", [])),
         }, indent=2, default=str)
 
     if response_mode == "standard":
@@ -2500,6 +2718,7 @@ def verify_dashboard_structure(
             "layout_orphans": report.get("layout_orphans"),
             "scope_orphans": report.get("scope_orphans"),
             "attached_missing_layout": report.get("attached_missing_layout"),
+            "duplicate_chart_placements": report.get("duplicate_chart_placements"),
         }, indent=2, default=str)
 
     return json.dumps({
@@ -3422,6 +3641,57 @@ def repair_dashboard_chart_refs(
     )
 
 
+@mcp.tool()
+@_handle_errors
+def repair_dashboard_layout_duplicates(
+    dashboard_id: int,
+    dry_run: bool = False,
+) -> str:
+    """Remove duplicate chart placements from a dashboard layout."""
+    ws = _get_ws()
+    before = capture_before(ws, "dashboard", dashboard_id)
+    if "_snapshot_error" in before:
+        raise ValueError(
+            f"Dashboard {dashboard_id} not found. Use list_dashboards to find valid IDs."
+        )
+
+    position = _ensure_json_dict(before.get("position_json", {}), "position_json")
+    duplicate_chart_placements = _find_duplicate_chart_placements(position)
+    if not duplicate_chart_placements:
+        return json.dumps({
+            "status": "noop",
+            "dashboard_id": dashboard_id,
+            "duplicate_chart_placements": [],
+            "message": "No duplicate chart placements found.",
+        }, indent=2, default=str)
+
+    cleaned = _deduplicate_layout_containers(position)
+
+    return _do_mutation(
+        tool_name="repair_dashboard_layout_duplicates",
+        resource_type="dashboard",
+        action="update",
+        fields_changed=["position_json"],
+        dry_run=dry_run,
+        execute=lambda: ws.update_dashboard(
+            dashboard_id,
+            position_json=json.dumps(cleaned),
+        ),
+        resource_id=dashboard_id,
+        before=before,
+        preview_extras={
+            "duplicate_chart_placements": duplicate_chart_placements,
+            "nodes_before": len(position),
+            "nodes_after": len(cleaned),
+        },
+        result_extras={
+            "duplicate_chart_placements_fixed": duplicate_chart_placements,
+            "nodes_before": len(position),
+            "nodes_after": len(cleaned),
+        },
+    )
+
+
 # ===================================================================
 # Tools — Snapshot
 # ===================================================================
@@ -3561,6 +3831,7 @@ def restore_dashboard_snapshot(
     dashboard_id: int,
     snapshot_path: str,
     restore_json_metadata: bool = True,
+    allow_id_mismatch: bool = False,
     dry_run: bool = False,
 ) -> str:
     """Restore dashboard layout/settings from a local snapshot JSON file."""
@@ -3581,10 +3852,12 @@ def restore_dashboard_snapshot(
 
     snap_dashboard_id = _to_int(snapshot.get("id"))
     if snap_dashboard_id is not None and snap_dashboard_id != dashboard_id:
-        raise ValueError(
-            f"Snapshot dashboard id {snap_dashboard_id} does not match requested "
-            f"dashboard_id {dashboard_id}."
-        )
+        if not allow_id_mismatch:
+            raise ValueError(
+                f"Snapshot dashboard id {snap_dashboard_id} does not match requested "
+                f"dashboard_id {dashboard_id}. Pass allow_id_mismatch=True to "
+                "restore this snapshot into a different dashboard."
+            )
 
     restored_position = _ensure_json_dict(snapshot.get("position_json"), "position_json")
     _validate_position_layout(restored_position)
@@ -3608,6 +3881,7 @@ def restore_dashboard_snapshot(
         preview_extras={
             "snapshot_path": str(path),
             "restore_json_metadata": restore_json_metadata,
+            "allow_id_mismatch": allow_id_mismatch,
         },
         result_extras={
             "_restored_from_snapshot": str(path),
@@ -3615,6 +3889,7 @@ def restore_dashboard_snapshot(
         after_extras={
             "snapshot_path": str(path),
             "restore_json_metadata": restore_json_metadata,
+            "allow_id_mismatch": allow_id_mismatch,
         },
     )
 

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -597,6 +597,90 @@ def test_restore_dashboard_snapshot_updates_layout(monkeypatch, tmp_path) -> Non
     assert "json_metadata" in ws.updated
 
 
+def test_restore_dashboard_snapshot_rejects_mismatched_dashboard_id(monkeypatch, tmp_path) -> None:
+    snapshots = tmp_path / "snapshots"
+    snapshots.mkdir(parents=True, exist_ok=True)
+    snapshot = snapshots / "dashboard_80_20260304T120000Z.json"
+    snapshot.write_text(
+        json.dumps(
+            {
+                "id": 80,
+                "position_json": {
+                    "DASHBOARD_VERSION_KEY": "v2",
+                    "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+                    "GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": [], "parents": ["ROOT_ID"]},
+                },
+                "json_metadata": {"chartsInScope": {}},
+            }
+        )
+    )
+
+    class _WS(_WorkspaceBase):
+        def dashboards(self):
+            return [{"id": 80}, {"id": 81}]
+
+        def dashboard_detail(self, dashboard_id: int):
+            return {"id": dashboard_id}
+
+    monkeypatch.setattr(server, "_get_ws", lambda: _WS())
+
+    with pytest.raises(ToolError) as exc:
+        server.restore_dashboard_snapshot.fn(
+            dashboard_id=81,
+            snapshot_path=str(snapshot),
+            restore_json_metadata=True,
+        )
+    payload = _validation_payload(exc.value)
+    assert "allow_id_mismatch=True" in payload["error"]
+
+
+def test_restore_dashboard_snapshot_allows_mismatched_dashboard_id(monkeypatch, tmp_path) -> None:
+    snapshots = tmp_path / "snapshots"
+    snapshots.mkdir(parents=True, exist_ok=True)
+    snapshot = snapshots / "dashboard_80_20260304T120000Z.json"
+    snapshot.write_text(
+        json.dumps(
+            {
+                "id": 80,
+                "position_json": {
+                    "DASHBOARD_VERSION_KEY": "v2",
+                    "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+                    "GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": [], "parents": ["ROOT_ID"]},
+                },
+                "json_metadata": {"chartsInScope": {}},
+            }
+        )
+    )
+
+    class _WS(_WorkspaceBase):
+        def __init__(self) -> None:
+            self.updated = None
+
+        def dashboards(self):
+            return [{"id": 80}, {"id": 81}]
+
+        def dashboard_detail(self, dashboard_id: int):
+            return {"id": dashboard_id}
+
+        def update_dashboard(self, dashboard_id: int, **kwargs):
+            self.updated = kwargs
+            return {"id": dashboard_id, **kwargs}
+
+    ws = _WS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+
+    raw = server.restore_dashboard_snapshot.fn(
+        dashboard_id=81,
+        snapshot_path=str(snapshot),
+        restore_json_metadata=True,
+        allow_id_mismatch=True,
+    )
+    payload = json.loads(raw)
+    assert payload["id"] == 81
+    assert ws.updated is not None
+
+
 def test_list_dashboard_snapshots_filters_by_dashboard(monkeypatch, tmp_path) -> None:
     snapshots = tmp_path / "snapshots"
     snapshots.mkdir(parents=True, exist_ok=True)
@@ -669,6 +753,38 @@ def test_verify_dashboard_structure_detects_layout_issues(monkeypatch) -> None:
     assert payload["status"] == "failed"
     assert payload["dangling_children"]
     assert payload["scope_orphans"] == [999]
+
+
+def test_verify_dashboard_structure_detects_duplicate_chart_placements(monkeypatch) -> None:
+    class _WS(_WorkspaceBase):
+        def dashboard_detail(self, dashboard_id: int):
+            return {
+                "id": dashboard_id,
+                "dashboard_title": "Duplicate Layout",
+                "position_json": {
+                    "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+                    "GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": ["ROW-1", "ROW-2"], "parents": ["ROOT_ID"]},
+                    "ROW-1": {"id": "ROW-1", "type": "ROW", "children": ["CHART-A"], "parents": ["GRID_ID"]},
+                    "ROW-2": {"id": "ROW-2", "type": "ROW", "children": ["CHART-B"], "parents": ["GRID_ID"]},
+                    "CHART-A": {"id": "CHART-A", "type": "CHART", "meta": {"chartId": 101}, "children": [], "parents": ["ROW-1"]},
+                    "CHART-B": {"id": "CHART-B", "type": "CHART", "meta": {"chartId": 101}, "children": [], "parents": ["ROW-2"]},
+                },
+                "json_metadata": {},
+            }
+
+        def dashboard_charts(self, dashboard_id: int):
+            return [{"id": 101, "slice_name": "Volume"}]
+
+    monkeypatch.setattr(server, "_get_ws", lambda: _WS())
+    raw = server.verify_dashboard_structure.fn(
+        dashboard_id=80,
+        response_mode="standard",
+    )
+    payload = json.loads(raw)
+    assert payload["status"] == "warning"
+    assert payload["duplicate_chart_placements"] == [
+        {"chart_id": 101, "layout_nodes": ["CHART-A", "CHART-B"]}
+    ]
 
 
 def test_verify_dashboard_workflow_reports_failed_query(monkeypatch) -> None:
@@ -952,6 +1068,72 @@ def test_verify_dashboard_structure_detects_missing_node_ids(monkeypatch) -> Non
     assert "ROOT_ID" in payload["missing_id_nodes"]
     assert "GRID_ID" in payload["missing_id_nodes"]
     assert "GRID_ID" in payload["missing_type_nodes"]
+
+
+# ===================================================================
+# Issues #39 / #40 / #41 — duplicate layout repair + snapshot portability
+# ===================================================================
+
+
+def test_deduplicate_layout_containers_removes_duplicate_row_subtree_without_mixing_layout() -> None:
+    position = {
+        "DASHBOARD_VERSION_KEY": "v2",
+        "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+        "GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": ["ROW-ORIG", "ROW-DUPE"], "parents": ["ROOT_ID"]},
+        "ROW-ORIG": {"id": "ROW-ORIG", "type": "ROW", "children": ["CHART-Z1", "CHART-A2"], "parents": ["GRID_ID"]},
+        "ROW-DUPE": {"id": "ROW-DUPE", "type": "ROW", "children": ["CHART-A1", "CHART-Z2"], "parents": ["GRID_ID"]},
+        "CHART-Z1": {"id": "CHART-Z1", "type": "CHART", "meta": {"chartId": 1}, "children": [], "parents": ["ROW-ORIG"]},
+        "CHART-A2": {"id": "CHART-A2", "type": "CHART", "meta": {"chartId": 2}, "children": [], "parents": ["ROW-ORIG"]},
+        "CHART-A1": {"id": "CHART-A1", "type": "CHART", "meta": {"chartId": 1}, "children": [], "parents": ["ROW-DUPE"]},
+        "CHART-Z2": {"id": "CHART-Z2", "type": "CHART", "meta": {"chartId": 2}, "children": [], "parents": ["ROW-DUPE"]},
+    }
+
+    cleaned = server._deduplicate_layout_containers(position)
+
+    assert cleaned["GRID_ID"]["children"] == ["ROW-ORIG"]
+    assert cleaned["ROW-ORIG"]["children"] == ["CHART-Z1", "CHART-A2"]
+    assert "ROW-DUPE" not in cleaned
+    assert "CHART-A1" not in cleaned
+    assert "CHART-Z2" not in cleaned
+
+
+def test_repair_dashboard_layout_duplicates_updates_dashboard(monkeypatch) -> None:
+    duplicate_position = {
+        "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+        "GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": ["ROW-ORIG", "ROW-DUPE"], "parents": ["ROOT_ID"]},
+        "ROW-ORIG": {"id": "ROW-ORIG", "type": "ROW", "children": ["CHART-Z1", "CHART-A2"], "parents": ["GRID_ID"]},
+        "ROW-DUPE": {"id": "ROW-DUPE", "type": "ROW", "children": ["CHART-A1", "CHART-Z2"], "parents": ["GRID_ID"]},
+        "CHART-Z1": {"id": "CHART-Z1", "type": "CHART", "meta": {"chartId": 1}, "children": [], "parents": ["ROW-ORIG"]},
+        "CHART-A2": {"id": "CHART-A2", "type": "CHART", "meta": {"chartId": 2}, "children": [], "parents": ["ROW-ORIG"]},
+        "CHART-A1": {"id": "CHART-A1", "type": "CHART", "meta": {"chartId": 1}, "children": [], "parents": ["ROW-DUPE"]},
+        "CHART-Z2": {"id": "CHART-Z2", "type": "CHART", "meta": {"chartId": 2}, "children": [], "parents": ["ROW-DUPE"]},
+    }
+
+    class _WS(_WorkspaceBase):
+        def __init__(self) -> None:
+            self.updated_kwargs = None
+
+        def get_resource(self, resource_type: str, resource_id: int):
+            return {"id": resource_id, "position_json": duplicate_position}
+
+        def update_dashboard(self, dashboard_id: int, **kwargs):
+            self.updated_kwargs = kwargs
+            return {"id": dashboard_id}
+
+    ws = _WS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+
+    raw = server.repair_dashboard_layout_duplicates.fn(
+        dashboard_id=80,
+        dry_run=False,
+    )
+    payload = json.loads(raw)
+    updated_position = json.loads(ws.updated_kwargs["position_json"])
+
+    assert payload["id"] == 80
+    assert updated_position["GRID_ID"]["children"] == ["ROW-ORIG"]
+    assert "ROW-DUPE" not in updated_position
 
 
 # ===================================================================


### PR DESCRIPTION
## Scope

Focused replacement branch for the dashboard recovery slice only. This PR intentionally stays limited to the existing dashboard repair and snapshot surface on main.

## What changed

- detect duplicate chart placements in verify_dashboard_structure
- add repair_dashboard_layout_duplicates for duplicate layout cleanup
- use subtree-aware deduplication to avoid hybrid row preservation
- allow restore_dashboard_snapshot(..., allow_id_mismatch=True) for replacement dashboards
- add regression coverage for duplicate placement detection, mixed duplicate rows, and mismatched snapshot restore

## Issue mapping

- addresses #39
- addresses #40
- addresses #41

## Deliberately not included

- no saved query, CSS template, annotation, or embedded dashboard work
- no token-response cleanup changes
- no new always-available import or export lifecycle tools

## Validation

- uv run --with pytest python -m pytest tests/test_server_tools.py
- uv run --with pytest python -m pytest