### PR TITLE
Add Preset resource tools with hardened API handling

### DIFF
--- a/src/preset_py/client.py
+++ b/src/preset_py/client.py
@@ -1648,6 +1648,204 @@ class PresetWorkspace:
         return self._client.import_zip(resource_type, BytesIO(data), overwrite=overwrite)
 
     # ------------------------------------------------------------------
+    # Saved Queries
+    # ------------------------------------------------------------------
+
+    def saved_queries(self, **filters: Any) -> list[dict[str, Any]]:
+        """List all saved queries in the workspace."""
+        return self._client.get_resources("saved_query", **filters)
+
+    def saved_query_detail(self, query_id: int) -> dict[str, Any]:
+        """Fetch a single saved query by ID."""
+        return self._client.get_resource("saved_query", query_id)
+
+    def create_saved_query(
+        self,
+        label: str,
+        sql: str,
+        database_id: int,
+        schema: str | None = None,
+        description: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a new saved query."""
+        payload: dict[str, Any] = {
+            "label": label,
+            "sql": sql,
+            "db_id": database_id,
+        }
+        if schema:
+            payload["schema"] = schema
+        if description:
+            payload["description"] = description
+        return self._client.create_resource("saved_query", **payload)
+
+    def update_saved_query(self, query_id: int, **kwargs: Any) -> dict[str, Any]:
+        """Update a saved query."""
+        return self._client.update_resource("saved_query", query_id, **kwargs)
+
+    def delete_saved_query(self, query_id: int) -> None:
+        """Delete a saved query."""
+        self._client.delete_resource("saved_query", query_id)
+
+    # ------------------------------------------------------------------
+    # CSS Templates
+    # ------------------------------------------------------------------
+
+    def css_templates(self, **filters: Any) -> list[dict[str, Any]]:
+        """List all CSS templates in the workspace."""
+        return self._client.get_resources("css_template", **filters)
+
+    def css_template_detail(self, template_id: int) -> dict[str, Any]:
+        """Fetch a single CSS template by ID."""
+        return self._client.get_resource("css_template", template_id)
+
+    def create_css_template(
+        self,
+        template_name: str,
+        css: str,
+    ) -> dict[str, Any]:
+        """Create a new CSS template."""
+        return self._client.create_resource(
+            "css_template",
+            template_name=template_name,
+            css=css,
+        )
+
+    def update_css_template(self, template_id: int, **kwargs: Any) -> dict[str, Any]:
+        """Update a CSS template."""
+        return self._client.update_resource("css_template", template_id, **kwargs)
+
+    def delete_css_template(self, template_id: int) -> None:
+        """Delete a CSS template."""
+        self._client.delete_resource("css_template", template_id)
+
+    # ------------------------------------------------------------------
+    # Annotation Layers
+    # ------------------------------------------------------------------
+
+    def annotation_layers(self, **filters: Any) -> list[dict[str, Any]]:
+        """List all annotation layers in the workspace."""
+        return self._client.get_resources("annotation_layer", **filters)
+
+    def annotation_layer_detail(self, layer_id: int) -> dict[str, Any]:
+        """Fetch a single annotation layer by ID."""
+        return self._client.get_resource("annotation_layer", layer_id)
+
+    def create_annotation_layer(
+        self,
+        name: str,
+        descr: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a new annotation layer."""
+        payload: dict[str, Any] = {"name": name}
+        if descr:
+            payload["descr"] = descr
+        return self._client.create_resource("annotation_layer", **payload)
+
+    def update_annotation_layer(self, layer_id: int, **kwargs: Any) -> dict[str, Any]:
+        """Update an annotation layer."""
+        return self._client.update_resource("annotation_layer", layer_id, **kwargs)
+
+    def delete_annotation_layer(self, layer_id: int) -> None:
+        """Delete an annotation layer."""
+        self._client.delete_resource("annotation_layer", layer_id)
+
+    def annotation_layer_annotations(self, layer_id: int) -> list[dict[str, Any]]:
+        """List annotations within an annotation layer."""
+        endpoint = str(
+            self._client.baseurl / "api/v1" / "annotation_layer"
+            / str(layer_id) / "annotation" / ""
+        )
+        response = self._client.session.get(endpoint)
+        payload = response.json()
+        return payload.get("result", [])
+
+    def create_annotation(
+        self,
+        layer_id: int,
+        short_descr: str,
+        start_dttm: str,
+        end_dttm: str,
+        long_descr: str | None = None,
+        json_metadata: str | None = None,
+    ) -> dict[str, Any]:
+        """Create an annotation in a layer."""
+        endpoint = str(
+            self._client.baseurl / "api/v1" / "annotation_layer"
+            / str(layer_id) / "annotation" / ""
+        )
+        body: dict[str, Any] = {
+            "short_descr": short_descr,
+            "start_dttm": start_dttm,
+            "end_dttm": end_dttm,
+        }
+        if long_descr:
+            body["long_descr"] = long_descr
+        if json_metadata:
+            body["json_metadata"] = json_metadata
+        response = self._client.session.post(endpoint, json=body)
+        return response.json()
+
+    def delete_annotation(self, layer_id: int, annotation_id: int) -> None:
+        """Delete an annotation from a layer."""
+        endpoint = str(
+            self._client.baseurl / "api/v1" / "annotation_layer"
+            / str(layer_id) / "annotation" / str(annotation_id)
+        )
+        self._client.session.delete(endpoint)
+
+    # ------------------------------------------------------------------
+    # Async Query Results
+    # ------------------------------------------------------------------
+
+    def async_query_result(self, query_id: str) -> dict[str, Any]:
+        """Fetch the result of an async SQL query by its query ID / key."""
+        endpoint = str(
+            self._client.baseurl / "api/v1" / "sqllab" / "results"
+        )
+        response = self._client.session.get(endpoint, params={"key": query_id})
+        return response.json()
+
+    # ------------------------------------------------------------------
+    # Embedded Dashboards
+    # ------------------------------------------------------------------
+
+    def get_embedded_dashboard(self, dashboard_id: int) -> dict[str, Any] | None:
+        """Get the embedded configuration for a dashboard, if it exists."""
+        endpoint = str(
+            self._client.baseurl / "api/v1" / "dashboard"
+            / str(dashboard_id) / "embedded"
+        )
+        response = self._client.session.get(endpoint)
+        if response.status_code == 404:
+            return None
+        return response.json().get("result")
+
+    def create_embedded_dashboard(
+        self,
+        dashboard_id: int,
+        allowed_domains: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Enable embedding for a dashboard and return the embed config (uuid)."""
+        endpoint = str(
+            self._client.baseurl / "api/v1" / "dashboard"
+            / str(dashboard_id) / "embedded"
+        )
+        body: dict[str, Any] = {
+            "allowed_domains": allowed_domains or [],
+        }
+        response = self._client.session.post(endpoint, json=body)
+        return response.json().get("result", response.json())
+
+    def delete_embedded_dashboard(self, dashboard_id: int) -> None:
+        """Disable embedding for a dashboard."""
+        endpoint = str(
+            self._client.baseurl / "api/v1" / "dashboard"
+            / str(dashboard_id) / "embedded"
+        )
+        self._client.session.delete(endpoint)
+
+    # ------------------------------------------------------------------
     # Snapshot
     # ------------------------------------------------------------------
 

--- a/src/preset_py/client.py
+++ b/src/preset_py/client.py
@@ -618,6 +618,38 @@ def _chart_data_error_message(body: Any) -> str:
     return error_message
 
 
+def _api_error_message(body: Any) -> str:
+    """Translate generic API error payloads into a stable error message."""
+    messages: list[str] = []
+    if isinstance(body, dict):
+        for key in ("message", "error", "detail"):
+            value = body.get(key)
+            if isinstance(value, str) and value.strip():
+                messages.append(value.strip())
+            elif value not in (None, ""):
+                messages.append(json.dumps(value, default=str))
+
+        errors = body.get("errors")
+        if isinstance(errors, list):
+            for item in errors:
+                if isinstance(item, dict):
+                    value = item.get("message") or item.get("error") or item.get("detail")
+                    if value:
+                        messages.append(str(value))
+                elif item not in (None, ""):
+                    messages.append(str(item))
+    elif isinstance(body, list):
+        for item in body:
+            if item not in (None, ""):
+                messages.append(str(item))
+    elif body not in (None, ""):
+        messages.append(str(body))
+
+    if not messages:
+        return "Preset API request failed with an empty API error payload."
+    return " | ".join(dict.fromkeys(messages))
+
+
 def _infer_dataset_time_column(dataset: dict[str, Any]) -> str | None:
     """Infer a default datetime column when exactly one exists."""
     raw_columns = dataset.get("columns")
@@ -804,6 +836,66 @@ class PresetWorkspace:
                 "or pass a workspace name to connect()."
             )
         return self._superset
+
+    def _request_json(
+        self,
+        method: Literal["get", "post", "put", "delete"],
+        endpoint: str,
+        operation: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+        allow_404: bool = False,
+    ) -> dict[str, Any]:
+        request = getattr(self._client.session, method)
+        kwargs: dict[str, Any] = {}
+        if params is not None:
+            kwargs["params"] = params
+        if json_body is not None:
+            kwargs["json"] = json_body
+
+        response = request(endpoint, **kwargs)
+        if allow_404 and response.status_code == 404:
+            return {}
+
+        try:
+            body = response.json()
+        except Exception as exc:
+            raise ValueError(
+                f"{operation} received a non-JSON response (HTTP {response.status_code})."
+            ) from exc
+
+        if response.status_code < 200 or response.status_code >= 300:
+            raise ValueError(f"{operation} failed: {_api_error_message(body)}")
+        if not isinstance(body, dict):
+            raise ValueError(f"{operation} received malformed API response.")
+        return body
+
+    def _request_ok(
+        self,
+        method: Literal["delete", "post", "put"],
+        endpoint: str,
+        operation: str,
+        *,
+        json_body: dict[str, Any] | None = None,
+    ) -> None:
+        request = getattr(self._client.session, method)
+        kwargs: dict[str, Any] = {}
+        if json_body is not None:
+            kwargs["json"] = json_body
+
+        response = request(endpoint, **kwargs)
+        if 200 <= response.status_code < 300:
+            return
+
+        try:
+            body = response.json()
+        except Exception:
+            text = response.text[:400] if getattr(response, "text", "") else "non-JSON response"
+            raise ValueError(
+                f"{operation} failed with HTTP {response.status_code}: {text}"
+            )
+        raise ValueError(f"{operation} failed: {_api_error_message(body)}")
 
     # ------------------------------------------------------------------
     # Workspace navigation
@@ -1756,9 +1848,15 @@ class PresetWorkspace:
             self._client.baseurl / "api/v1" / "annotation_layer"
             / str(layer_id) / "annotation" / ""
         )
-        response = self._client.session.get(endpoint)
-        payload = response.json()
-        return payload.get("result", [])
+        payload = self._request_json(
+            "get",
+            endpoint,
+            f"List annotations for annotation layer {layer_id}",
+        )
+        result = payload.get("result", [])
+        if not isinstance(result, list):
+            raise ValueError("List annotations received malformed API response.")
+        return result
 
     def create_annotation(
         self,
@@ -1783,8 +1881,16 @@ class PresetWorkspace:
             body["long_descr"] = long_descr
         if json_metadata:
             body["json_metadata"] = json_metadata
-        response = self._client.session.post(endpoint, json=body)
-        return response.json()
+        payload = self._request_json(
+            "post",
+            endpoint,
+            f"Create annotation in layer {layer_id}",
+            json_body=body,
+        )
+        result = payload.get("result", payload)
+        if not isinstance(result, dict):
+            raise ValueError("Create annotation received malformed API response.")
+        return result
 
     def delete_annotation(self, layer_id: int, annotation_id: int) -> None:
         """Delete an annotation from a layer."""
@@ -1792,7 +1898,11 @@ class PresetWorkspace:
             self._client.baseurl / "api/v1" / "annotation_layer"
             / str(layer_id) / "annotation" / str(annotation_id)
         )
-        self._client.session.delete(endpoint)
+        self._request_ok(
+            "delete",
+            endpoint,
+            f"Delete annotation {annotation_id} from layer {layer_id}",
+        )
 
     # ------------------------------------------------------------------
     # Async Query Results
@@ -1803,8 +1913,12 @@ class PresetWorkspace:
         endpoint = str(
             self._client.baseurl / "api/v1" / "sqllab" / "results"
         )
-        response = self._client.session.get(endpoint, params={"key": query_id})
-        return response.json()
+        return self._request_json(
+            "get",
+            endpoint,
+            f"Fetch async query result {query_id}",
+            params={"key": query_id},
+        )
 
     # ------------------------------------------------------------------
     # Embedded Dashboards
@@ -1816,10 +1930,20 @@ class PresetWorkspace:
             self._client.baseurl / "api/v1" / "dashboard"
             / str(dashboard_id) / "embedded"
         )
-        response = self._client.session.get(endpoint)
-        if response.status_code == 404:
+        payload = self._request_json(
+            "get",
+            endpoint,
+            f"Fetch embedded dashboard configuration for dashboard {dashboard_id}",
+            allow_404=True,
+        )
+        if not payload:
             return None
-        return response.json().get("result")
+        result = payload.get("result", payload)
+        if not isinstance(result, dict):
+            raise ValueError(
+                "Fetch embedded dashboard configuration received malformed API response."
+            )
+        return result
 
     def create_embedded_dashboard(
         self,
@@ -1834,8 +1958,16 @@ class PresetWorkspace:
         body: dict[str, Any] = {
             "allowed_domains": allowed_domains or [],
         }
-        response = self._client.session.post(endpoint, json=body)
-        return response.json().get("result", response.json())
+        payload = self._request_json(
+            "post",
+            endpoint,
+            f"Enable embedding for dashboard {dashboard_id}",
+            json_body=body,
+        )
+        result = payload.get("result", payload)
+        if not isinstance(result, dict):
+            raise ValueError("Enable embedding received malformed API response.")
+        return result
 
     def delete_embedded_dashboard(self, dashboard_id: int) -> None:
         """Disable embedding for a dashboard."""
@@ -1843,7 +1975,11 @@ class PresetWorkspace:
             self._client.baseurl / "api/v1" / "dashboard"
             / str(dashboard_id) / "embedded"
         )
-        self._client.session.delete(endpoint)
+        self._request_ok(
+            "delete",
+            endpoint,
+            f"Disable embedding for dashboard {dashboard_id}",
+        )
 
     # ------------------------------------------------------------------
     # Snapshot

--- a/src/preset_py/server.py
+++ b/src/preset_py/server.py
@@ -3838,6 +3838,757 @@ if _DELETE_ENABLED:
 
 
 # ===================================================================
+# Tools — Saved Queries
+# ===================================================================
+
+
+@mcp.tool()
+@_handle_errors
+def list_saved_queries(
+    response_mode: ResponseMode = "standard",
+    name_contains: str | None = None,
+) -> str:
+    """List saved SQL queries in the current workspace.
+
+    Saved queries are reusable SQL snippets stored in SQL Lab.
+    Use this to discover query IDs, then pass one to get_saved_query
+    for full detail.
+
+    Args:
+        response_mode: 'compact' (id+label), 'standard' (key fields),
+                       or 'full' (raw API response).  Default: standard.
+        name_contains: Case-insensitive substring filter on the query label.
+    """
+    ws = _get_ws()
+    records = ws.saved_queries()
+    if name_contains:
+        needle = name_contains.lower()
+        records = [
+            r for r in records
+            if needle in str(r.get("label", "")).lower()
+        ]
+    if response_mode == "compact":
+        data = _pick(records, ["id", "label", "db_id"])
+    elif response_mode == "standard":
+        data = _pick(records, [
+            "id", "label", "db_id", "schema", "sql",
+            "changed_on", "description",
+        ])
+    else:
+        data = records
+    out: dict[str, Any] = {
+        "count": len(records),
+        "response_mode": response_mode,
+        "data": data,
+    }
+    if response_mode != "full":
+        out["hint"] = "Set response_mode='full' to see all fields."
+    return json.dumps(out, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_errors
+def get_saved_query(
+    query_id: int,
+    response_mode: ResponseMode = "standard",
+) -> str:
+    """Get detail for a single saved query.
+
+    Args:
+        query_id: The saved query ID.
+        response_mode: 'compact', 'standard', or 'full'.
+    """
+    ws = _get_ws()
+    record = ws.saved_query_detail(query_id)
+    if response_mode == "compact":
+        data = {k: record[k] for k in ["id", "label", "db_id", "schema"] if k in record}
+    elif response_mode == "standard":
+        data = {k: record[k] for k in [
+            "id", "label", "db_id", "schema", "sql",
+            "description", "changed_on",
+        ] if k in record}
+    else:
+        data = record
+    out: dict[str, Any] = {"response_mode": response_mode, "data": data}
+    if response_mode != "full":
+        out["hint"] = "Set response_mode='full' to see all fields."
+    return json.dumps(out, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_errors
+def create_saved_query(
+    label: str,
+    sql: str,
+    database_id: int,
+    schema: str | None = None,
+    description: str | None = None,
+    dry_run: bool = False,
+) -> str:
+    """Create a new saved SQL query in SQL Lab.
+
+    Saved queries persist reusable SQL snippets associated with a database.
+
+    Args:
+        label: Name / label for the saved query.
+        sql: The SQL text to save.
+        database_id: ID of the database this query targets.
+        schema: Optional schema context (e.g. 'public').
+        description: Optional description of the query.
+        dry_run: If True, preview the action without executing.
+    """
+    ws = _get_ws()
+    fields = ["label", "sql", "db_id"]
+    if schema:
+        fields.append("schema")
+    if description:
+        fields.append("description")
+
+    return _do_mutation(
+        tool_name="create_saved_query",
+        resource_type="saved_query",
+        action="create",
+        fields_changed=fields,
+        dry_run=dry_run,
+        execute=lambda: ws.create_saved_query(
+            label=label, sql=sql, database_id=database_id,
+            schema=schema, description=description,
+        ),
+    )
+
+
+@mcp.tool()
+@_handle_errors
+def update_saved_query(
+    query_id: int,
+    label: str | None = None,
+    sql: str | None = None,
+    description: str | None = None,
+    schema: str | None = None,
+    dry_run: bool = False,
+) -> str:
+    """Update an existing saved query.
+
+    Args:
+        query_id: The saved query ID to update.
+        label: New label (name) for the query.
+        sql: New SQL text.
+        description: New description.
+        schema: New schema context.
+        dry_run: If True, preview the action without executing.
+    """
+    ws = _get_ws()
+    kwargs: dict[str, Any] = {}
+    if label is not None:
+        kwargs["label"] = label
+    if sql is not None:
+        kwargs["sql"] = sql
+    if description is not None:
+        kwargs["description"] = description
+    if schema is not None:
+        kwargs["schema"] = schema
+
+    if not kwargs:
+        raise ValueError("No fields to update. Pass at least one of: label, sql, description, schema.")
+
+    before = capture_before(ws, "saved_query", query_id)
+
+    return _do_mutation(
+        tool_name="update_saved_query",
+        resource_type="saved_query",
+        action="update",
+        resource_id=query_id,
+        fields_changed=list(kwargs.keys()),
+        dry_run=dry_run,
+        before=before,
+        execute=lambda: ws.update_saved_query(query_id, **kwargs),
+    )
+
+
+@mcp.tool()
+@_handle_errors
+def delete_saved_query(
+    query_id: int,
+    dry_run: bool = False,
+) -> str:
+    """Delete a saved query.
+
+    Args:
+        query_id: The saved query ID to delete.
+        dry_run: If True, preview the action without executing.
+    """
+    ws = _get_ws()
+    before = capture_before(ws, "saved_query", query_id)
+
+    return _do_mutation(
+        tool_name="delete_saved_query",
+        resource_type="saved_query",
+        action="delete",
+        resource_id=query_id,
+        fields_changed=[],
+        dry_run=dry_run,
+        before=before,
+        execute=lambda: ws.delete_saved_query(query_id) or {},
+    )
+
+
+# ===================================================================
+# Tools — CSS Templates
+# ===================================================================
+
+
+@mcp.tool()
+@_handle_errors
+def list_css_templates(
+    response_mode: ResponseMode = "standard",
+    name_contains: str | None = None,
+) -> str:
+    """List CSS templates in the current workspace.
+
+    CSS templates define reusable dashboard styling.  Use this to discover
+    template IDs, then pass one to get_css_template for full detail.
+
+    Args:
+        response_mode: 'compact' (id+name), 'standard' (key fields),
+                       or 'full' (raw API response).  Default: standard.
+        name_contains: Case-insensitive substring filter on template_name.
+    """
+    ws = _get_ws()
+    records = ws.css_templates()
+    if name_contains:
+        needle = name_contains.lower()
+        records = [
+            r for r in records
+            if needle in str(r.get("template_name", "")).lower()
+        ]
+    if response_mode == "compact":
+        data = _pick(records, ["id", "template_name"])
+    elif response_mode == "standard":
+        data = _pick(records, [
+            "id", "template_name", "css", "changed_on",
+        ])
+    else:
+        data = records
+    out: dict[str, Any] = {
+        "count": len(records),
+        "response_mode": response_mode,
+        "data": data,
+    }
+    if response_mode != "full":
+        out["hint"] = "Set response_mode='full' to see all fields."
+    return json.dumps(out, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_errors
+def get_css_template(
+    template_id: int,
+    response_mode: ResponseMode = "standard",
+) -> str:
+    """Get detail for a single CSS template.
+
+    Args:
+        template_id: The CSS template ID.
+        response_mode: 'compact', 'standard', or 'full'.
+    """
+    ws = _get_ws()
+    record = ws.css_template_detail(template_id)
+    if response_mode == "compact":
+        data = {k: record[k] for k in ["id", "template_name"] if k in record}
+    elif response_mode == "standard":
+        data = {k: record[k] for k in [
+            "id", "template_name", "css", "changed_on",
+        ] if k in record}
+    else:
+        data = record
+    out: dict[str, Any] = {"response_mode": response_mode, "data": data}
+    if response_mode != "full":
+        out["hint"] = "Set response_mode='full' to see all fields."
+    return json.dumps(out, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_errors
+def create_css_template(
+    template_name: str,
+    css: str,
+    dry_run: bool = False,
+) -> str:
+    """Create a new CSS template for dashboard styling.
+
+    Args:
+        template_name: Name for the CSS template.
+        css: The CSS stylesheet text.
+        dry_run: If True, preview the action without executing.
+    """
+    ws = _get_ws()
+
+    return _do_mutation(
+        tool_name="create_css_template",
+        resource_type="css_template",
+        action="create",
+        fields_changed=["template_name", "css"],
+        dry_run=dry_run,
+        execute=lambda: ws.create_css_template(
+            template_name=template_name, css=css,
+        ),
+    )
+
+
+@mcp.tool()
+@_handle_errors
+def update_css_template(
+    template_id: int,
+    template_name: str | None = None,
+    css: str | None = None,
+    dry_run: bool = False,
+) -> str:
+    """Update an existing CSS template.
+
+    Args:
+        template_id: The CSS template ID to update.
+        template_name: New name for the template.
+        css: New CSS stylesheet text.
+        dry_run: If True, preview the action without executing.
+    """
+    ws = _get_ws()
+    kwargs: dict[str, Any] = {}
+    if template_name is not None:
+        kwargs["template_name"] = template_name
+    if css is not None:
+        kwargs["css"] = css
+
+    if not kwargs:
+        raise ValueError("No fields to update. Pass at least one of: template_name, css.")
+
+    before = capture_before(ws, "css_template", template_id)
+
+    return _do_mutation(
+        tool_name="update_css_template",
+        resource_type="css_template",
+        action="update",
+        resource_id=template_id,
+        fields_changed=list(kwargs.keys()),
+        dry_run=dry_run,
+        before=before,
+        execute=lambda: ws.update_css_template(template_id, **kwargs),
+    )
+
+
+@mcp.tool()
+@_handle_errors
+def delete_css_template(
+    template_id: int,
+    dry_run: bool = False,
+) -> str:
+    """Delete a CSS template.
+
+    Args:
+        template_id: The CSS template ID to delete.
+        dry_run: If True, preview the action without executing.
+    """
+    ws = _get_ws()
+    before = capture_before(ws, "css_template", template_id)
+
+    return _do_mutation(
+        tool_name="delete_css_template",
+        resource_type="css_template",
+        action="delete",
+        resource_id=template_id,
+        fields_changed=[],
+        dry_run=dry_run,
+        before=before,
+        execute=lambda: ws.delete_css_template(template_id) or {},
+    )
+
+
+# ===================================================================
+# Tools — Annotation Layers
+# ===================================================================
+
+
+@mcp.tool()
+@_handle_errors
+def list_annotation_layers(
+    response_mode: ResponseMode = "standard",
+    name_contains: str | None = None,
+) -> str:
+    """List annotation layers in the current workspace.
+
+    Annotation layers let you overlay time-based markers on charts
+    (e.g. deploys, incidents).  Use this to discover layer IDs.
+
+    Args:
+        response_mode: 'compact' (id+name), 'standard' (key fields),
+                       or 'full' (raw API response).  Default: standard.
+        name_contains: Case-insensitive substring filter on layer name.
+    """
+    ws = _get_ws()
+    records = ws.annotation_layers()
+    if name_contains:
+        needle = name_contains.lower()
+        records = [
+            r for r in records
+            if needle in str(r.get("name", "")).lower()
+        ]
+    if response_mode == "compact":
+        data = _pick(records, ["id", "name"])
+    elif response_mode == "standard":
+        data = _pick(records, [
+            "id", "name", "descr", "changed_on",
+        ])
+    else:
+        data = records
+    out: dict[str, Any] = {
+        "count": len(records),
+        "response_mode": response_mode,
+        "data": data,
+    }
+    if response_mode != "full":
+        out["hint"] = "Set response_mode='full' to see all fields."
+    return json.dumps(out, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_errors
+def get_annotation_layer(
+    layer_id: int,
+    response_mode: ResponseMode = "standard",
+) -> str:
+    """Get detail for a single annotation layer including its annotations.
+
+    Args:
+        layer_id: The annotation layer ID.
+        response_mode: 'compact', 'standard', or 'full'.
+    """
+    ws = _get_ws()
+    record = ws.annotation_layer_detail(layer_id)
+    annotations = ws.annotation_layer_annotations(layer_id)
+
+    if response_mode == "compact":
+        data = {k: record[k] for k in ["id", "name"] if k in record}
+        data["annotation_count"] = len(annotations)
+    elif response_mode == "standard":
+        data = {k: record[k] for k in [
+            "id", "name", "descr", "changed_on",
+        ] if k in record}
+        data["annotations"] = [
+            {k: a[k] for k in ["id", "short_descr", "start_dttm", "end_dttm"] if k in a}
+            for a in annotations
+        ]
+    else:
+        data = record
+        data["annotations"] = annotations
+    out: dict[str, Any] = {"response_mode": response_mode, "data": data}
+    if response_mode != "full":
+        out["hint"] = "Set response_mode='full' to see all fields."
+    return json.dumps(out, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_errors
+def create_annotation_layer(
+    name: str,
+    descr: str | None = None,
+    dry_run: bool = False,
+) -> str:
+    """Create a new annotation layer.
+
+    Annotation layers group time-based annotations that can be overlaid
+    on time-series charts.  After creating a layer, use create_annotation
+    to add individual annotations.
+
+    Args:
+        name: Name for the annotation layer.
+        descr: Optional description.
+        dry_run: If True, preview the action without executing.
+    """
+    ws = _get_ws()
+    fields = ["name"]
+    if descr:
+        fields.append("descr")
+
+    return _do_mutation(
+        tool_name="create_annotation_layer",
+        resource_type="annotation_layer",
+        action="create",
+        fields_changed=fields,
+        dry_run=dry_run,
+        execute=lambda: ws.create_annotation_layer(name=name, descr=descr),
+    )
+
+
+@mcp.tool()
+@_handle_errors
+def update_annotation_layer(
+    layer_id: int,
+    name: str | None = None,
+    descr: str | None = None,
+    dry_run: bool = False,
+) -> str:
+    """Update an existing annotation layer.
+
+    Args:
+        layer_id: The annotation layer ID to update.
+        name: New name for the layer.
+        descr: New description.
+        dry_run: If True, preview the action without executing.
+    """
+    ws = _get_ws()
+    kwargs: dict[str, Any] = {}
+    if name is not None:
+        kwargs["name"] = name
+    if descr is not None:
+        kwargs["descr"] = descr
+
+    if not kwargs:
+        raise ValueError("No fields to update. Pass at least one of: name, descr.")
+
+    before = capture_before(ws, "annotation_layer", layer_id)
+
+    return _do_mutation(
+        tool_name="update_annotation_layer",
+        resource_type="annotation_layer",
+        action="update",
+        resource_id=layer_id,
+        fields_changed=list(kwargs.keys()),
+        dry_run=dry_run,
+        before=before,
+        execute=lambda: ws.update_annotation_layer(layer_id, **kwargs),
+    )
+
+
+@mcp.tool()
+@_handle_errors
+def delete_annotation_layer(
+    layer_id: int,
+    dry_run: bool = False,
+) -> str:
+    """Delete an annotation layer and all its annotations.
+
+    Args:
+        layer_id: The annotation layer ID to delete.
+        dry_run: If True, preview the action without executing.
+    """
+    ws = _get_ws()
+    before = capture_before(ws, "annotation_layer", layer_id)
+
+    return _do_mutation(
+        tool_name="delete_annotation_layer",
+        resource_type="annotation_layer",
+        action="delete",
+        resource_id=layer_id,
+        fields_changed=[],
+        dry_run=dry_run,
+        before=before,
+        execute=lambda: ws.delete_annotation_layer(layer_id) or {},
+    )
+
+
+@mcp.tool()
+@_handle_errors
+def create_annotation(
+    layer_id: int,
+    short_descr: str,
+    start_dttm: str,
+    end_dttm: str,
+    long_descr: str | None = None,
+    dry_run: bool = False,
+) -> str:
+    """Add an annotation to an existing annotation layer.
+
+    Annotations are time-based markers that overlay on time-series charts.
+    Use list_annotation_layers or get_annotation_layer to find layer IDs.
+
+    Args:
+        layer_id: The annotation layer ID to add this annotation to.
+        short_descr: Short description (label) shown on the chart overlay.
+        start_dttm: Start datetime in ISO 8601 format (e.g. '2024-01-15T00:00:00').
+        end_dttm: End datetime in ISO 8601 format (e.g. '2024-01-16T00:00:00').
+        long_descr: Optional longer description with details.
+        dry_run: If True, preview the action without executing.
+    """
+    ws = _get_ws()
+    fields = ["short_descr", "start_dttm", "end_dttm"]
+    if long_descr:
+        fields.append("long_descr")
+
+    return _do_mutation(
+        tool_name="create_annotation",
+        resource_type="annotation",
+        action="create",
+        fields_changed=fields,
+        dry_run=dry_run,
+        execute=lambda: ws.create_annotation(
+            layer_id=layer_id,
+            short_descr=short_descr,
+            start_dttm=start_dttm,
+            end_dttm=end_dttm,
+            long_descr=long_descr,
+        ),
+    )
+
+
+@mcp.tool()
+@_handle_errors
+def delete_annotation(
+    layer_id: int,
+    annotation_id: int,
+    dry_run: bool = False,
+) -> str:
+    """Delete a specific annotation from an annotation layer.
+
+    Args:
+        layer_id: The annotation layer ID.
+        annotation_id: The annotation ID to delete.
+        dry_run: If True, preview the action without executing.
+    """
+    ws = _get_ws()
+
+    return _do_mutation(
+        tool_name="delete_annotation",
+        resource_type="annotation",
+        action="delete",
+        resource_id=annotation_id,
+        fields_changed=[],
+        dry_run=dry_run,
+        execute=lambda: ws.delete_annotation(layer_id, annotation_id) or {},
+    )
+
+
+# ===================================================================
+# Tools — Async Query Results
+# ===================================================================
+
+
+@mcp.tool()
+@_handle_errors
+def get_async_query_result(
+    query_id: str,
+) -> str:
+    """Fetch results of an async SQL query by its query ID (key).
+
+    When SQL Lab runs a query asynchronously, it returns a query ID
+    (also called a 'key').  Use this tool to poll for and retrieve
+    the results once the query completes.
+
+    Args:
+        query_id: The query ID / key returned by an async SQL Lab query.
+    """
+    ws = _get_ws()
+    result = ws.async_query_result(query_id)
+    return json.dumps(result, indent=2, default=str)
+
+
+# ===================================================================
+# Tools — Embedded Dashboards
+# ===================================================================
+
+
+@mcp.tool()
+@_handle_errors
+def get_embedded_dashboard(
+    dashboard_id: int,
+) -> str:
+    """Get the embedded configuration for a dashboard.
+
+    Returns the embedding UUID and allowed domains if embedding is enabled,
+    or indicates that embedding is not configured.
+
+    Args:
+        dashboard_id: The dashboard ID.
+    """
+    ws = _get_ws()
+    result = ws.get_embedded_dashboard(dashboard_id)
+    if result is None:
+        return json.dumps({
+            "dashboard_id": dashboard_id,
+            "embedded": False,
+            "hint": "Use enable_embedded_dashboard to enable embedding.",
+        }, indent=2)
+    return json.dumps({
+        "dashboard_id": dashboard_id,
+        "embedded": True,
+        "data": result,
+    }, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_errors
+def enable_embedded_dashboard(
+    dashboard_id: int,
+    allowed_domains: list[str] | str | None = None,
+    dry_run: bool = False,
+) -> str:
+    """Enable embedding for a dashboard and return its embed UUID.
+
+    The returned UUID is used to embed the dashboard in external
+    applications via the Superset embedded SDK.
+
+    Args:
+        dashboard_id: The dashboard ID to enable embedding for.
+        allowed_domains: List of domains allowed to embed (e.g.
+                         '["app.example.com"]').  Pass an empty list to
+                         allow all origins.
+        dry_run: If True, preview the action without executing.
+    """
+    ws = _get_ws()
+    domains: list[str] = []
+    if isinstance(allowed_domains, str):
+        try:
+            parsed = json.loads(allowed_domains)
+            if isinstance(parsed, list):
+                domains = [str(d) for d in parsed]
+            else:
+                domains = [str(allowed_domains)]
+        except (json.JSONDecodeError, TypeError):
+            domains = [d.strip() for d in allowed_domains.split(",") if d.strip()]
+    elif isinstance(allowed_domains, list):
+        domains = [str(d) for d in allowed_domains]
+
+    return _do_mutation(
+        tool_name="enable_embedded_dashboard",
+        resource_type="dashboard",
+        action="update",
+        resource_id=dashboard_id,
+        fields_changed=["embedded", "allowed_domains"],
+        dry_run=dry_run,
+        execute=lambda: ws.create_embedded_dashboard(
+            dashboard_id=dashboard_id,
+            allowed_domains=domains,
+        ),
+    )
+
+
+@mcp.tool()
+@_handle_errors
+def disable_embedded_dashboard(
+    dashboard_id: int,
+    dry_run: bool = False,
+) -> str:
+    """Disable embedding for a dashboard.
+
+    This revokes the embed UUID and prevents the dashboard from being
+    embedded in external applications.
+
+    Args:
+        dashboard_id: The dashboard ID to disable embedding for.
+        dry_run: If True, preview the action without executing.
+    """
+    ws = _get_ws()
+
+    return _do_mutation(
+        tool_name="disable_embedded_dashboard",
+        resource_type="dashboard",
+        action="update",
+        resource_id=dashboard_id,
+        fields_changed=["embedded"],
+        dry_run=dry_run,
+        execute=lambda: ws.delete_embedded_dashboard(dashboard_id) or {},
+    )
+
+
+# ===================================================================
 # Entry point
 # ===================================================================
 

--- a/src/preset_py/server.py
+++ b/src/preset_py/server.py
@@ -4277,8 +4277,7 @@ def get_annotation_layer(
             for a in annotations
         ]
     else:
-        data = record
-        data["annotations"] = annotations
+        data = {**record, "annotations": annotations}
     out: dict[str, Any] = {"response_mode": response_mode, "data": data}
     if response_mode != "full":
         out["hint"] = "Set response_mode='full' to see all fields."

--- a/tests/test_client_validation.py
+++ b/tests/test_client_validation.py
@@ -7,7 +7,7 @@ from preset_py.client import PresetWorkspace, _critical_page_errors
 
 
 class _FakeResponse:
-    def __init__(self, status_code: int, body: dict):
+    def __init__(self, status_code: int, body):
         self.status_code = status_code
         self._body = body
         self.text = json.dumps(body)
@@ -20,9 +20,17 @@ class _FakeSession:
     def __init__(self, response: _FakeResponse):
         self._response = response
         self.last_payload = None
+        self.last_params = None
 
     def post(self, _endpoint: str, json=None):
         self.last_payload = json
+        return self._response
+
+    def get(self, _endpoint: str, params=None):
+        self.last_params = params
+        return self._response
+
+    def delete(self, _endpoint: str):
         return self._response
 
 
@@ -335,3 +343,90 @@ def test_validate_chart_does_not_persist_when_existing_query_context_used() -> N
     ws.validate_chart_data(7, dashboard_id=None, persist_synthetic=True)
 
     assert client.update_chart_calls == []
+
+
+def test_get_embedded_dashboard_returns_none_on_404() -> None:
+    response = _FakeResponse(404, {"message": "Not found"})
+    client = _FakeSupersetClient(response)
+    ws = PresetWorkspace.__new__(PresetWorkspace)
+    ws._superset = client
+
+    assert ws.get_embedded_dashboard(44) is None
+
+
+def test_get_embedded_dashboard_raises_on_api_error() -> None:
+    response = _FakeResponse(500, {"message": "embed fetch failed"})
+    client = _FakeSupersetClient(response)
+    ws = PresetWorkspace.__new__(PresetWorkspace)
+    ws._superset = client
+
+    with pytest.raises(ValueError, match="embed fetch failed"):
+        ws.get_embedded_dashboard(44)
+
+
+def test_delete_embedded_dashboard_raises_on_api_error() -> None:
+    response = _FakeResponse(500, {"error": "delete failed"})
+    client = _FakeSupersetClient(response)
+    ws = PresetWorkspace.__new__(PresetWorkspace)
+    ws._superset = client
+
+    with pytest.raises(ValueError, match="delete failed"):
+        ws.delete_embedded_dashboard(44)
+
+
+def test_create_annotation_unwraps_result_payload() -> None:
+    response = _FakeResponse(201, {"result": {"id": 8, "short_descr": "Release"}})
+    client = _FakeSupersetClient(response)
+    ws = PresetWorkspace.__new__(PresetWorkspace)
+    ws._superset = client
+
+    created = ws.create_annotation(
+        layer_id=9,
+        short_descr="Release",
+        start_dttm="2026-03-01",
+        end_dttm="2026-03-02",
+        long_descr="launch",
+    )
+
+    assert created["id"] == 8
+    assert client.session.last_payload == {
+        "short_descr": "Release",
+        "start_dttm": "2026-03-01",
+        "end_dttm": "2026-03-02",
+        "long_descr": "launch",
+    }
+
+
+def test_create_annotation_raises_on_api_error() -> None:
+    response = _FakeResponse(400, {"message": "invalid annotation"})
+    client = _FakeSupersetClient(response)
+    ws = PresetWorkspace.__new__(PresetWorkspace)
+    ws._superset = client
+
+    with pytest.raises(ValueError, match="invalid annotation"):
+        ws.create_annotation(
+            layer_id=9,
+            short_descr="Release",
+            start_dttm="2026-03-01",
+            end_dttm="2026-03-02",
+        )
+
+
+def test_delete_annotation_raises_on_api_error() -> None:
+    response = _FakeResponse(500, {"error": "annotation delete failed"})
+    client = _FakeSupersetClient(response)
+    ws = PresetWorkspace.__new__(PresetWorkspace)
+    ws._superset = client
+
+    with pytest.raises(ValueError, match="annotation delete failed"):
+        ws.delete_annotation(9, 8)
+
+
+def test_async_query_result_raises_on_api_error() -> None:
+    response = _FakeResponse(500, {"message": "query failed"})
+    client = _FakeSupersetClient(response)
+    ws = PresetWorkspace.__new__(PresetWorkspace)
+    ws._superset = client
+
+    with pytest.raises(ValueError, match="query failed"):
+        ws.async_query_result("01JABC")

--- a/tests/test_new_tools.py
+++ b/tests/test_new_tools.py
@@ -197,7 +197,7 @@ def test_update_saved_query_execute(monkeypatch) -> None:
     raw = server.update_saved_query.fn(
         query_id=1, label="Updated label",
     )
-    payload = json.loads(raw)
+    json.loads(raw)
     assert ws.update_id == 1
     assert ws.update_kwargs == {"label": "Updated label"}
 
@@ -382,7 +382,7 @@ def test_update_css_template_execute(monkeypatch) -> None:
     raw = server.update_css_template.fn(
         template_id=1, css="body { color: red; }",
     )
-    payload = json.loads(raw)
+    json.loads(raw)
     assert ws.update_id == 1
     assert ws.update_kwargs == {"css": "body { color: red; }"}
 
@@ -584,7 +584,7 @@ def test_update_annotation_layer_execute(monkeypatch) -> None:
     monkeypatch.setattr(server, "record_mutation", lambda entry: None)
     monkeypatch.setattr(server, "capture_before", lambda ws, rt, rid: {"id": rid})
     raw = server.update_annotation_layer.fn(layer_id=1, name="Renamed")
-    payload = json.loads(raw)
+    json.loads(raw)
     assert ws.update_layer_id == 1
     assert ws.update_layer_kwargs == {"name": "Renamed"}
 
@@ -822,7 +822,7 @@ def test_enable_embedded_dashboard_with_json_string(monkeypatch) -> None:
         dashboard_id=42,
         allowed_domains='["app.example.com"]',
     )
-    payload = json.loads(raw)
+    json.loads(raw)
     assert ws.enable_domains == ["app.example.com"]
 
 
@@ -834,7 +834,7 @@ def test_enable_embedded_dashboard_with_comma_string(monkeypatch) -> None:
         dashboard_id=42,
         allowed_domains="app.example.com, staging.example.com",
     )
-    payload = json.loads(raw)
+    json.loads(raw)
     assert ws.enable_domains == ["app.example.com", "staging.example.com"]
 
 
@@ -843,7 +843,7 @@ def test_enable_embedded_dashboard_with_none(monkeypatch) -> None:
     monkeypatch.setattr(server, "_get_ws", lambda: ws)
     monkeypatch.setattr(server, "record_mutation", lambda entry: None)
     raw = server.enable_embedded_dashboard.fn(dashboard_id=42)
-    payload = json.loads(raw)
+    json.loads(raw)
     assert ws.enable_domains == []
 
 
@@ -867,7 +867,7 @@ def test_disable_embedded_dashboard_execute(monkeypatch) -> None:
     monkeypatch.setattr(server, "_get_ws", lambda: ws)
     monkeypatch.setattr(server, "record_mutation", lambda entry: None)
     raw = server.disable_embedded_dashboard.fn(dashboard_id=80)
-    payload = json.loads(raw)
+    json.loads(raw)
     assert ws.disable_dashboard_id == 80
 
 

--- a/tests/test_new_tools.py
+++ b/tests/test_new_tools.py
@@ -1,0 +1,936 @@
+"""Tests for the new MCP tools: saved queries, CSS templates,
+annotation layers, async query results, and embedded dashboards.
+
+Covers:
+  - list / get / create / update / delete for each resource type
+  - response_mode progressive disclosure (compact / standard / full)
+  - name_contains filtering
+  - dry_run vs execute paths
+  - validation (empty update kwargs)
+  - domain coercion for enable_embedded_dashboard
+  - no-mutation side-effect on annotation layer full-mode record
+  - error propagation through _handle_errors
+"""
+
+import json
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+import preset_py.server as server
+
+
+# ---------------------------------------------------------------------------
+# Shared workspace base (mirrors test_server_tools.py pattern)
+# ---------------------------------------------------------------------------
+
+
+class _WorkspaceBase:
+    """Minimal workspace stub with default helpers for monkeypatching."""
+
+    def get_resource(self, resource_type: str, resource_id: int):
+        return {"id": resource_id}
+
+
+# ===================================================================
+# Saved Queries
+# ===================================================================
+
+_SAVED_QUERIES = [
+    {
+        "id": 1, "label": "Revenue by region",
+        "db_id": 10, "schema": "public",
+        "sql": "SELECT region, SUM(rev) FROM sales GROUP BY 1",
+        "description": "Quarterly revenue", "changed_on": "2026-01-01",
+    },
+    {
+        "id": 2, "label": "Active users",
+        "db_id": 10, "schema": "analytics",
+        "sql": "SELECT COUNT(*) FROM users WHERE active",
+        "description": "DAU count", "changed_on": "2026-02-01",
+    },
+]
+
+
+class _SavedQueryWS(_WorkspaceBase):
+    def __init__(self) -> None:
+        self.create_kwargs: dict | None = None
+        self.update_id: int | None = None
+        self.update_kwargs: dict | None = None
+        self.deleted_id: int | None = None
+
+    def saved_queries(self):
+        return list(_SAVED_QUERIES)
+
+    def saved_query_detail(self, query_id: int):
+        for q in _SAVED_QUERIES:
+            if q["id"] == query_id:
+                return dict(q)
+        raise ValueError(f"not found: {query_id}")
+
+    def create_saved_query(self, **kwargs):
+        self.create_kwargs = kwargs
+        return {"id": 99, **kwargs}
+
+    def update_saved_query(self, query_id: int, **kwargs):
+        self.update_id = query_id
+        self.update_kwargs = kwargs
+        return {"id": query_id, "result": "ok"}
+
+    def delete_saved_query(self, query_id: int):
+        self.deleted_id = query_id
+
+
+# -- list --
+
+
+def test_list_saved_queries_compact(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _SavedQueryWS())
+    raw = server.list_saved_queries.fn(response_mode="compact")
+    payload = json.loads(raw)
+    assert payload["count"] == 2
+    assert payload["response_mode"] == "compact"
+    # compact should only have id, label, db_id
+    first = payload["data"][0]
+    assert set(first.keys()) == {"id", "label", "db_id"}
+
+
+def test_list_saved_queries_standard(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _SavedQueryWS())
+    raw = server.list_saved_queries.fn(response_mode="standard")
+    payload = json.loads(raw)
+    first = payload["data"][0]
+    assert "sql" in first
+    assert "description" in first
+    assert "hint" in payload
+
+
+def test_list_saved_queries_full(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _SavedQueryWS())
+    raw = server.list_saved_queries.fn(response_mode="full")
+    payload = json.loads(raw)
+    assert "hint" not in payload
+    # full mode returns all original fields
+    first = payload["data"][0]
+    assert "changed_on" in first
+
+
+def test_list_saved_queries_name_filter(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _SavedQueryWS())
+    raw = server.list_saved_queries.fn(name_contains="revenue")
+    payload = json.loads(raw)
+    assert payload["count"] == 1
+    assert payload["data"][0]["label"] == "Revenue by region"
+
+
+def test_list_saved_queries_name_filter_no_match(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _SavedQueryWS())
+    raw = server.list_saved_queries.fn(name_contains="nonexistent")
+    payload = json.loads(raw)
+    assert payload["count"] == 0
+
+
+# -- get --
+
+
+def test_get_saved_query_compact(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _SavedQueryWS())
+    raw = server.get_saved_query.fn(query_id=1, response_mode="compact")
+    payload = json.loads(raw)
+    assert payload["data"]["id"] == 1
+    assert "sql" not in payload["data"]
+
+
+def test_get_saved_query_standard(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _SavedQueryWS())
+    raw = server.get_saved_query.fn(query_id=1, response_mode="standard")
+    payload = json.loads(raw)
+    assert payload["data"]["sql"] == "SELECT region, SUM(rev) FROM sales GROUP BY 1"
+
+
+def test_get_saved_query_full(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _SavedQueryWS())
+    raw = server.get_saved_query.fn(query_id=2, response_mode="full")
+    payload = json.loads(raw)
+    assert payload["data"]["label"] == "Active users"
+    assert "hint" not in payload
+
+
+# -- create --
+
+
+def test_create_saved_query_execute(monkeypatch) -> None:
+    ws = _SavedQueryWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    raw = server.create_saved_query.fn(
+        label="New query", sql="SELECT 1", database_id=10,
+        schema="public", description="test",
+    )
+    payload = json.loads(raw)
+    assert payload["id"] == 99
+    assert ws.create_kwargs["label"] == "New query"
+    assert ws.create_kwargs["database_id"] == 10
+    assert ws.create_kwargs["schema"] == "public"
+
+
+def test_create_saved_query_dry_run(monkeypatch) -> None:
+    ws = _SavedQueryWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    raw = server.create_saved_query.fn(
+        label="New query", sql="SELECT 1", database_id=10, dry_run=True,
+    )
+    payload = json.loads(raw)
+    assert payload["dry_run"] is True
+    assert ws.create_kwargs is None  # not executed
+
+
+# -- update --
+
+
+def test_update_saved_query_execute(monkeypatch) -> None:
+    ws = _SavedQueryWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    monkeypatch.setattr(server, "capture_before", lambda ws, rt, rid: {"id": rid})
+    raw = server.update_saved_query.fn(
+        query_id=1, label="Updated label",
+    )
+    payload = json.loads(raw)
+    assert ws.update_id == 1
+    assert ws.update_kwargs == {"label": "Updated label"}
+
+
+def test_update_saved_query_no_fields_raises(monkeypatch) -> None:
+    ws = _SavedQueryWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    with pytest.raises(ToolError):
+        server.update_saved_query.fn(query_id=1)
+
+
+def test_update_saved_query_dry_run(monkeypatch) -> None:
+    ws = _SavedQueryWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    monkeypatch.setattr(server, "capture_before", lambda ws, rt, rid: {"id": rid})
+    raw = server.update_saved_query.fn(
+        query_id=1, sql="SELECT 2", dry_run=True,
+    )
+    payload = json.loads(raw)
+    assert payload["dry_run"] is True
+    assert payload["fields_to_change"] == ["sql"]
+    assert ws.update_id is None  # not executed
+
+
+# -- delete --
+
+
+def test_delete_saved_query_execute(monkeypatch) -> None:
+    ws = _SavedQueryWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    monkeypatch.setattr(server, "capture_before", lambda ws, rt, rid: {"id": rid})
+    raw = server.delete_saved_query.fn(query_id=1)
+    payload = json.loads(raw)
+    assert payload["status"] == "deleted"
+    assert payload["saved_query_id"] == 1
+    assert ws.deleted_id == 1
+
+
+def test_delete_saved_query_dry_run(monkeypatch) -> None:
+    ws = _SavedQueryWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    monkeypatch.setattr(server, "capture_before", lambda ws, rt, rid: {"id": rid})
+    raw = server.delete_saved_query.fn(query_id=1, dry_run=True)
+    payload = json.loads(raw)
+    assert payload["dry_run"] is True
+    assert ws.deleted_id is None
+
+
+# ===================================================================
+# CSS Templates
+# ===================================================================
+
+_CSS_TEMPLATES = [
+    {
+        "id": 1, "template_name": "Dark Theme",
+        "css": ".dashboard { background: #1a1a1a; }",
+        "changed_on": "2026-01-15",
+    },
+    {
+        "id": 2, "template_name": "Brand Colors",
+        "css": ".header { color: #ff6600; }",
+        "changed_on": "2026-02-15",
+    },
+]
+
+
+class _CssTemplateWS(_WorkspaceBase):
+    def __init__(self) -> None:
+        self.create_kwargs: dict | None = None
+        self.update_id: int | None = None
+        self.update_kwargs: dict | None = None
+        self.deleted_id: int | None = None
+
+    def css_templates(self):
+        return list(_CSS_TEMPLATES)
+
+    def css_template_detail(self, template_id: int):
+        for t in _CSS_TEMPLATES:
+            if t["id"] == template_id:
+                return dict(t)
+        raise ValueError(f"not found: {template_id}")
+
+    def create_css_template(self, **kwargs):
+        self.create_kwargs = kwargs
+        return {"id": 99, **kwargs}
+
+    def update_css_template(self, template_id: int, **kwargs):
+        self.update_id = template_id
+        self.update_kwargs = kwargs
+        return {"id": template_id, "result": "ok"}
+
+    def delete_css_template(self, template_id: int):
+        self.deleted_id = template_id
+
+
+# -- list --
+
+
+def test_list_css_templates_compact(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _CssTemplateWS())
+    raw = server.list_css_templates.fn(response_mode="compact")
+    payload = json.loads(raw)
+    assert payload["count"] == 2
+    first = payload["data"][0]
+    assert set(first.keys()) == {"id", "template_name"}
+
+
+def test_list_css_templates_standard(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _CssTemplateWS())
+    raw = server.list_css_templates.fn(response_mode="standard")
+    payload = json.loads(raw)
+    first = payload["data"][0]
+    assert "css" in first
+    assert "changed_on" in first
+
+
+def test_list_css_templates_name_filter(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _CssTemplateWS())
+    raw = server.list_css_templates.fn(name_contains="dark")
+    payload = json.loads(raw)
+    assert payload["count"] == 1
+    assert payload["data"][0]["template_name"] == "Dark Theme"
+
+
+# -- get --
+
+
+def test_get_css_template_compact(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _CssTemplateWS())
+    raw = server.get_css_template.fn(template_id=1, response_mode="compact")
+    payload = json.loads(raw)
+    assert set(payload["data"].keys()) == {"id", "template_name"}
+
+
+def test_get_css_template_full(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _CssTemplateWS())
+    raw = server.get_css_template.fn(template_id=1, response_mode="full")
+    payload = json.loads(raw)
+    assert payload["data"]["css"] == ".dashboard { background: #1a1a1a; }"
+    assert "hint" not in payload
+
+
+# -- create --
+
+
+def test_create_css_template_execute(monkeypatch) -> None:
+    ws = _CssTemplateWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    raw = server.create_css_template.fn(
+        template_name="New Style", css="body { margin: 0; }",
+    )
+    payload = json.loads(raw)
+    assert payload["id"] == 99
+    assert ws.create_kwargs["template_name"] == "New Style"
+    assert ws.create_kwargs["css"] == "body { margin: 0; }"
+
+
+def test_create_css_template_dry_run(monkeypatch) -> None:
+    ws = _CssTemplateWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    raw = server.create_css_template.fn(
+        template_name="New Style", css="body { margin: 0; }", dry_run=True,
+    )
+    payload = json.loads(raw)
+    assert payload["dry_run"] is True
+    assert ws.create_kwargs is None
+
+
+# -- update --
+
+
+def test_update_css_template_execute(monkeypatch) -> None:
+    ws = _CssTemplateWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    monkeypatch.setattr(server, "capture_before", lambda ws, rt, rid: {"id": rid})
+    raw = server.update_css_template.fn(
+        template_id=1, css="body { color: red; }",
+    )
+    payload = json.loads(raw)
+    assert ws.update_id == 1
+    assert ws.update_kwargs == {"css": "body { color: red; }"}
+
+
+def test_update_css_template_no_fields_raises(monkeypatch) -> None:
+    ws = _CssTemplateWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    with pytest.raises(ToolError):
+        server.update_css_template.fn(template_id=1)
+
+
+# -- delete --
+
+
+def test_delete_css_template_execute(monkeypatch) -> None:
+    ws = _CssTemplateWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    monkeypatch.setattr(server, "capture_before", lambda ws, rt, rid: {"id": rid})
+    raw = server.delete_css_template.fn(template_id=1)
+    payload = json.loads(raw)
+    assert payload["status"] == "deleted"
+    assert ws.deleted_id == 1
+
+
+def test_delete_css_template_dry_run(monkeypatch) -> None:
+    ws = _CssTemplateWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    monkeypatch.setattr(server, "capture_before", lambda ws, rt, rid: {"id": rid})
+    raw = server.delete_css_template.fn(template_id=1, dry_run=True)
+    payload = json.loads(raw)
+    assert payload["dry_run"] is True
+    assert ws.deleted_id is None
+
+
+# ===================================================================
+# Annotation Layers
+# ===================================================================
+
+_ANNOTATION_LAYERS = [
+    {"id": 1, "name": "Deploys", "descr": "Production deploys", "changed_on": "2026-01-01"},
+    {"id": 2, "name": "Incidents", "descr": "SEV1 incidents", "changed_on": "2026-02-01"},
+]
+
+_ANNOTATIONS = [
+    {"id": 10, "short_descr": "v2.0 release", "start_dttm": "2026-01-15T00:00:00", "end_dttm": "2026-01-15T01:00:00"},
+    {"id": 11, "short_descr": "v2.1 hotfix", "start_dttm": "2026-02-01T00:00:00", "end_dttm": "2026-02-01T00:30:00"},
+]
+
+
+class _AnnotationWS(_WorkspaceBase):
+    def __init__(self) -> None:
+        self.create_layer_kwargs: dict | None = None
+        self.update_layer_id: int | None = None
+        self.update_layer_kwargs: dict | None = None
+        self.deleted_layer_id: int | None = None
+        self.create_ann_kwargs: dict | None = None
+        self.deleted_ann: tuple | None = None
+
+    def annotation_layers(self):
+        return list(_ANNOTATION_LAYERS)
+
+    def annotation_layer_detail(self, layer_id: int):
+        for layer in _ANNOTATION_LAYERS:
+            if layer["id"] == layer_id:
+                return dict(layer)
+        raise ValueError(f"not found: {layer_id}")
+
+    def annotation_layer_annotations(self, layer_id: int):
+        return list(_ANNOTATIONS)
+
+    def create_annotation_layer(self, **kwargs):
+        self.create_layer_kwargs = kwargs
+        return {"id": 99, **kwargs}
+
+    def update_annotation_layer(self, layer_id: int, **kwargs):
+        self.update_layer_id = layer_id
+        self.update_layer_kwargs = kwargs
+        return {"id": layer_id, "result": "ok"}
+
+    def delete_annotation_layer(self, layer_id: int):
+        self.deleted_layer_id = layer_id
+
+    def create_annotation(self, **kwargs):
+        self.create_ann_kwargs = kwargs
+        return {"id": 50, **kwargs}
+
+    def delete_annotation(self, layer_id: int, annotation_id: int):
+        self.deleted_ann = (layer_id, annotation_id)
+
+
+# -- list layers --
+
+
+def test_list_annotation_layers_compact(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _AnnotationWS())
+    raw = server.list_annotation_layers.fn(response_mode="compact")
+    payload = json.loads(raw)
+    assert payload["count"] == 2
+    first = payload["data"][0]
+    assert set(first.keys()) == {"id", "name"}
+
+
+def test_list_annotation_layers_standard(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _AnnotationWS())
+    raw = server.list_annotation_layers.fn(response_mode="standard")
+    payload = json.loads(raw)
+    first = payload["data"][0]
+    assert "descr" in first
+    assert "changed_on" in first
+
+
+def test_list_annotation_layers_name_filter(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _AnnotationWS())
+    raw = server.list_annotation_layers.fn(name_contains="deploy")
+    payload = json.loads(raw)
+    assert payload["count"] == 1
+    assert payload["data"][0]["name"] == "Deploys"
+
+
+# -- get layer --
+
+
+def test_get_annotation_layer_compact(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _AnnotationWS())
+    raw = server.get_annotation_layer.fn(layer_id=1, response_mode="compact")
+    payload = json.loads(raw)
+    assert payload["data"]["id"] == 1
+    assert payload["data"]["annotation_count"] == 2
+    assert "annotations" not in payload["data"]
+
+
+def test_get_annotation_layer_standard(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _AnnotationWS())
+    raw = server.get_annotation_layer.fn(layer_id=1, response_mode="standard")
+    payload = json.loads(raw)
+    annotations = payload["data"]["annotations"]
+    assert len(annotations) == 2
+    assert annotations[0]["short_descr"] == "v2.0 release"
+
+
+def test_get_annotation_layer_full(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _AnnotationWS())
+    raw = server.get_annotation_layer.fn(layer_id=1, response_mode="full")
+    payload = json.loads(raw)
+    assert payload["data"]["annotations"] == _ANNOTATIONS
+    assert "hint" not in payload
+
+
+def test_get_annotation_layer_full_does_not_mutate_original(monkeypatch) -> None:
+    """Ensure full mode doesn't mutate the record returned by the workspace."""
+    ws = _AnnotationWS()
+    original_record = ws.annotation_layer_detail(1)
+    assert "annotations" not in original_record
+
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    server.get_annotation_layer.fn(layer_id=1, response_mode="full")
+
+    # The original record should not have been mutated
+    fresh_record = ws.annotation_layer_detail(1)
+    assert "annotations" not in fresh_record
+
+
+# -- create layer --
+
+
+def test_create_annotation_layer_execute(monkeypatch) -> None:
+    ws = _AnnotationWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    raw = server.create_annotation_layer.fn(
+        name="Maintenance Windows", descr="Planned downtime",
+    )
+    payload = json.loads(raw)
+    assert payload["id"] == 99
+    assert ws.create_layer_kwargs["name"] == "Maintenance Windows"
+    assert ws.create_layer_kwargs["descr"] == "Planned downtime"
+
+
+def test_create_annotation_layer_dry_run(monkeypatch) -> None:
+    ws = _AnnotationWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    raw = server.create_annotation_layer.fn(
+        name="Test", dry_run=True,
+    )
+    payload = json.loads(raw)
+    assert payload["dry_run"] is True
+    assert ws.create_layer_kwargs is None
+
+
+# -- update layer --
+
+
+def test_update_annotation_layer_execute(monkeypatch) -> None:
+    ws = _AnnotationWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    monkeypatch.setattr(server, "capture_before", lambda ws, rt, rid: {"id": rid})
+    raw = server.update_annotation_layer.fn(layer_id=1, name="Renamed")
+    payload = json.loads(raw)
+    assert ws.update_layer_id == 1
+    assert ws.update_layer_kwargs == {"name": "Renamed"}
+
+
+def test_update_annotation_layer_no_fields_raises(monkeypatch) -> None:
+    ws = _AnnotationWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    with pytest.raises(ToolError):
+        server.update_annotation_layer.fn(layer_id=1)
+
+
+# -- delete layer --
+
+
+def test_delete_annotation_layer_execute(monkeypatch) -> None:
+    ws = _AnnotationWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    monkeypatch.setattr(server, "capture_before", lambda ws, rt, rid: {"id": rid})
+    raw = server.delete_annotation_layer.fn(layer_id=1)
+    payload = json.loads(raw)
+    assert payload["status"] == "deleted"
+    assert ws.deleted_layer_id == 1
+
+
+def test_delete_annotation_layer_dry_run(monkeypatch) -> None:
+    ws = _AnnotationWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    monkeypatch.setattr(server, "capture_before", lambda ws, rt, rid: {"id": rid})
+    raw = server.delete_annotation_layer.fn(layer_id=1, dry_run=True)
+    payload = json.loads(raw)
+    assert payload["dry_run"] is True
+    assert ws.deleted_layer_id is None
+
+
+# -- create annotation --
+
+
+def test_create_annotation_execute(monkeypatch) -> None:
+    ws = _AnnotationWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    raw = server.create_annotation.fn(
+        layer_id=1,
+        short_descr="Deploy v3.0",
+        start_dttm="2026-03-01T00:00:00",
+        end_dttm="2026-03-01T01:00:00",
+        long_descr="Major release",
+    )
+    payload = json.loads(raw)
+    assert payload["id"] == 50
+    assert ws.create_ann_kwargs["layer_id"] == 1
+    assert ws.create_ann_kwargs["short_descr"] == "Deploy v3.0"
+    assert ws.create_ann_kwargs["long_descr"] == "Major release"
+
+
+def test_create_annotation_dry_run(monkeypatch) -> None:
+    ws = _AnnotationWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    raw = server.create_annotation.fn(
+        layer_id=1,
+        short_descr="Test",
+        start_dttm="2026-03-01T00:00:00",
+        end_dttm="2026-03-01T01:00:00",
+        dry_run=True,
+    )
+    payload = json.loads(raw)
+    assert payload["dry_run"] is True
+    assert ws.create_ann_kwargs is None
+
+
+def test_create_annotation_fields_include_long_descr_when_provided(monkeypatch) -> None:
+    ws = _AnnotationWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    raw = server.create_annotation.fn(
+        layer_id=1,
+        short_descr="test",
+        start_dttm="2026-03-01T00:00:00",
+        end_dttm="2026-03-01T01:00:00",
+        long_descr="details here",
+        dry_run=True,
+    )
+    payload = json.loads(raw)
+    assert "long_descr" in payload["fields_to_change"]
+
+
+def test_create_annotation_fields_omit_long_descr_when_absent(monkeypatch) -> None:
+    ws = _AnnotationWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    raw = server.create_annotation.fn(
+        layer_id=1,
+        short_descr="test",
+        start_dttm="2026-03-01T00:00:00",
+        end_dttm="2026-03-01T01:00:00",
+        dry_run=True,
+    )
+    payload = json.loads(raw)
+    assert "long_descr" not in payload["fields_to_change"]
+
+
+# -- delete annotation --
+
+
+def test_delete_annotation_execute(monkeypatch) -> None:
+    ws = _AnnotationWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    raw = server.delete_annotation.fn(layer_id=1, annotation_id=10)
+    payload = json.loads(raw)
+    assert payload["status"] == "deleted"
+    assert payload["annotation_id"] == 10
+    assert ws.deleted_ann == (1, 10)
+
+
+def test_delete_annotation_dry_run(monkeypatch) -> None:
+    ws = _AnnotationWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    raw = server.delete_annotation.fn(layer_id=1, annotation_id=10, dry_run=True)
+    payload = json.loads(raw)
+    assert payload["dry_run"] is True
+    assert ws.deleted_ann is None
+
+
+# ===================================================================
+# Async Query Results
+# ===================================================================
+
+
+class _AsyncQueryWS(_WorkspaceBase):
+    def async_query_result(self, query_id: str):
+        if query_id == "abc-123":
+            return {
+                "status": "success",
+                "data": [{"col1": 1, "col2": "a"}],
+                "columns": ["col1", "col2"],
+                "query_id": query_id,
+            }
+        return {"status": "pending", "query_id": query_id}
+
+
+def test_get_async_query_result_success(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _AsyncQueryWS())
+    raw = server.get_async_query_result.fn(query_id="abc-123")
+    payload = json.loads(raw)
+    assert payload["status"] == "success"
+    assert payload["data"] == [{"col1": 1, "col2": "a"}]
+
+
+def test_get_async_query_result_pending(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _AsyncQueryWS())
+    raw = server.get_async_query_result.fn(query_id="unknown-key")
+    payload = json.loads(raw)
+    assert payload["status"] == "pending"
+
+
+# ===================================================================
+# Embedded Dashboards
+# ===================================================================
+
+
+class _EmbeddedWS(_WorkspaceBase):
+    def __init__(self) -> None:
+        self.enable_dashboard_id: int | None = None
+        self.enable_domains: list[str] | None = None
+        self.disable_dashboard_id: int | None = None
+
+    def get_embedded_dashboard(self, dashboard_id: int):
+        if dashboard_id == 80:
+            return {
+                "uuid": "abc-def-123",
+                "allowed_domains": ["app.example.com"],
+                "dashboard_id": "80",
+            }
+        return None
+
+    def create_embedded_dashboard(self, dashboard_id: int, allowed_domains=None):
+        self.enable_dashboard_id = dashboard_id
+        self.enable_domains = allowed_domains
+        return {
+            "uuid": "new-uuid-456",
+            "allowed_domains": allowed_domains or [],
+            "dashboard_id": str(dashboard_id),
+        }
+
+    def delete_embedded_dashboard(self, dashboard_id: int):
+        self.disable_dashboard_id = dashboard_id
+
+
+# -- get --
+
+
+def test_get_embedded_dashboard_enabled(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _EmbeddedWS())
+    raw = server.get_embedded_dashboard.fn(dashboard_id=80)
+    payload = json.loads(raw)
+    assert payload["embedded"] is True
+    assert payload["data"]["uuid"] == "abc-def-123"
+
+
+def test_get_embedded_dashboard_not_enabled(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _EmbeddedWS())
+    raw = server.get_embedded_dashboard.fn(dashboard_id=99)
+    payload = json.loads(raw)
+    assert payload["embedded"] is False
+    assert "hint" in payload
+
+
+# -- enable --
+
+
+def test_enable_embedded_dashboard_with_list(monkeypatch) -> None:
+    ws = _EmbeddedWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    raw = server.enable_embedded_dashboard.fn(
+        dashboard_id=42,
+        allowed_domains=["app.example.com", "staging.example.com"],
+    )
+    payload = json.loads(raw)
+    assert payload["uuid"] == "new-uuid-456"
+    assert ws.enable_dashboard_id == 42
+    assert ws.enable_domains == ["app.example.com", "staging.example.com"]
+
+
+def test_enable_embedded_dashboard_with_json_string(monkeypatch) -> None:
+    ws = _EmbeddedWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    raw = server.enable_embedded_dashboard.fn(
+        dashboard_id=42,
+        allowed_domains='["app.example.com"]',
+    )
+    payload = json.loads(raw)
+    assert ws.enable_domains == ["app.example.com"]
+
+
+def test_enable_embedded_dashboard_with_comma_string(monkeypatch) -> None:
+    ws = _EmbeddedWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    raw = server.enable_embedded_dashboard.fn(
+        dashboard_id=42,
+        allowed_domains="app.example.com, staging.example.com",
+    )
+    payload = json.loads(raw)
+    assert ws.enable_domains == ["app.example.com", "staging.example.com"]
+
+
+def test_enable_embedded_dashboard_with_none(monkeypatch) -> None:
+    ws = _EmbeddedWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    raw = server.enable_embedded_dashboard.fn(dashboard_id=42)
+    payload = json.loads(raw)
+    assert ws.enable_domains == []
+
+
+def test_enable_embedded_dashboard_dry_run(monkeypatch) -> None:
+    ws = _EmbeddedWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    raw = server.enable_embedded_dashboard.fn(
+        dashboard_id=42, dry_run=True,
+    )
+    payload = json.loads(raw)
+    assert payload["dry_run"] is True
+    assert ws.enable_dashboard_id is None
+
+
+# -- disable --
+
+
+def test_disable_embedded_dashboard_execute(monkeypatch) -> None:
+    ws = _EmbeddedWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    raw = server.disable_embedded_dashboard.fn(dashboard_id=80)
+    payload = json.loads(raw)
+    assert ws.disable_dashboard_id == 80
+
+
+def test_disable_embedded_dashboard_dry_run(monkeypatch) -> None:
+    ws = _EmbeddedWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    raw = server.disable_embedded_dashboard.fn(dashboard_id=80, dry_run=True)
+    payload = json.loads(raw)
+    assert payload["dry_run"] is True
+    assert ws.disable_dashboard_id is None
+
+
+# ===================================================================
+# Edge cases and error propagation
+# ===================================================================
+
+
+def test_saved_query_create_optional_fields_omitted_from_payload(monkeypatch) -> None:
+    """When schema and description are None, they should not be sent."""
+    ws = _SavedQueryWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    server.create_saved_query.fn(
+        label="Minimal", sql="SELECT 1", database_id=5,
+    )
+    assert ws.create_kwargs["schema"] is None
+    assert ws.create_kwargs["description"] is None
+
+
+def test_create_annotation_layer_no_descr(monkeypatch) -> None:
+    """Create layer without description still works."""
+    ws = _AnnotationWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    raw = server.create_annotation_layer.fn(name="Simple Layer")
+    payload = json.loads(raw)
+    assert payload["id"] == 99
+    assert ws.create_layer_kwargs["descr"] is None
+
+
+def test_workspace_error_propagated_as_tool_error(monkeypatch) -> None:
+    """Exceptions from workspace methods become ToolErrors via _handle_errors."""
+    class _BrokenWS(_WorkspaceBase):
+        def saved_queries(self):
+            raise RuntimeError("Connection refused")
+
+    monkeypatch.setattr(server, "_get_ws", lambda: _BrokenWS())
+    with pytest.raises(ToolError) as exc:
+        server.list_saved_queries.fn()
+    payload = json.loads(str(exc.value))
+    assert "Connection refused" in payload["error"]
+
+
+def test_update_saved_query_multiple_fields(monkeypatch) -> None:
+    """Updating multiple fields at once captures all field names."""
+    ws = _SavedQueryWS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+    monkeypatch.setattr(server, "capture_before", lambda ws, rt, rid: {"id": rid})
+    raw = server.update_saved_query.fn(
+        query_id=1, label="New", sql="SELECT 2", description="Updated", schema="new_schema",
+        dry_run=True,
+    )
+    payload = json.loads(raw)
+    assert set(payload["fields_to_change"]) == {"label", "sql", "description", "schema"}


### PR DESCRIPTION
## Summary
- split the non-dashboard resource tool surface out of #43 onto a fresh branch from `main`
- add saved query, CSS template, annotation layer, async query result, and embedded dashboard MCP tools already ported from #43
- harden the direct client API helpers so 4xx/5xx responses raise instead of silently looking like success
- add client-level failure-path tests and clean up dead test assignments flagged by lint

## Why this split
This branch carries the resource/tool surface from #43 without the dashboard lifecycle changes already moved to #44 and without the separate token-response cleanup commit.

## Verification
- `uv run --with pytest python -m pytest`
- `uv run ruff check src/preset_py/client.py tests/test_client_validation.py tests/test_new_tools.py`
