### PR TITLE
Reduce MCP response token overhead

### DIFF
--- a/src/preset_py/server.py
+++ b/src/preset_py/server.py
@@ -198,12 +198,9 @@ def _format_list(
 
     out: dict[str, Any] = {
         "count": len(records),
-        "response_mode": mode,
         "data": data,
     }
-    if mode != "full":
-        out["hint"] = "Set response_mode='full' to see all fields."
-    return json.dumps(out, indent=2, default=str)
+    return json.dumps(out, default=str)
 
 
 def _format_detail(record: dict, resource: str, mode: ResponseMode) -> str:
@@ -214,10 +211,7 @@ def _format_detail(record: dict, resource: str, mode: ResponseMode) -> str:
         data = {k: record[k] for k in _DETAIL_STANDARD.get(resource, []) if k in record}
     else:
         data = record
-    out: dict[str, Any] = {"response_mode": mode, "data": data}
-    if mode != "full":
-        out["hint"] = "Set response_mode='full' to see all fields."
-    return json.dumps(out, indent=2, default=str)
+    return json.dumps({"data": data}, default=str)
 
 
 def _format_sql(
@@ -230,23 +224,15 @@ def _format_sql(
     out: dict[str, Any] = {
         "rowcount": total,
         "columns": columns,
-        "response_mode": mode,
     }
 
     if mode == "compact":
-        out["hint"] = (
-            "Schema only. Use response_mode='standard' for sample rows "
-            "or 'full' for all rows."
-        )
+        pass  # schema-only: columns + rowcount
     elif mode == "standard":
         sample = records[:SQL_SAMPLE_ROWS]
         out["sample_rows"] = sample
         if total > SQL_SAMPLE_ROWS:
             out["truncated"] = True
-            out["hint"] = (
-                f"Showing {len(sample)}/{total} rows. "
-                "Use response_mode='full' for all rows."
-            )
     else:  # full
         if total > TRUNCATION_THRESHOLD:
             head_n = TRUNCATION_THRESHOLD - TRUNCATION_TAIL
@@ -263,7 +249,7 @@ def _format_sql(
             out["rows"] = records
             out["truncated"] = False
 
-    return json.dumps(out, indent=2, default=str)
+    return json.dumps(out, default=str)
 
 
 # ---------------------------------------------------------------------------
@@ -1430,7 +1416,7 @@ def _do_mutation(
             after_summary=dry_after,
             dry_run=True,
         ))
-        return json.dumps(preview, indent=2, default=str)
+        return json.dumps(preview, default=str)
 
     # -- Execute path -------------------------------------------------------
     result = execute()
@@ -1469,7 +1455,7 @@ def _do_mutation(
         after_summary=after_summary,
     ))
 
-    return json.dumps(response, indent=2, default=str)
+    return json.dumps(response, default=str)
 
 
 # ===================================================================
@@ -1486,7 +1472,7 @@ def list_workspaces() -> str:
     use_workspace.
     """
     ws = _get_ws()
-    return json.dumps(ws.list_workspaces(), indent=2)
+    return json.dumps(ws.list_workspaces())
 
 
 @mcp.tool()
@@ -1806,7 +1792,7 @@ def workspace_catalog() -> str:
     _log.info(
         "workspace_catalog counts=%s", catalog["counts"],
     )
-    return json.dumps(catalog, indent=2, default=str)
+    return json.dumps(catalog, default=str)
 
 
 # ===================================================================
@@ -2097,7 +2083,7 @@ def describe_dashboard(
             "dataset_count": len(dataset_inventory),
             "markdown_block_count": len(markdown_blocks),
             "warning_count": len(warnings),
-        }, indent=2, default=str)
+        }, default=str)
 
     result: dict[str, Any] = {
         "dashboard": dashboard_meta,
@@ -2112,7 +2098,7 @@ def describe_dashboard(
         result["warning_count"] = len(warnings)
         result["warnings_preview"] = warnings[:3]
 
-    return json.dumps(result, indent=2, default=str)
+    return json.dumps(result, default=str)
 
 
 # ===================================================================
@@ -2163,7 +2149,7 @@ def validate_chart(
             "dashboard_id": result.get("dashboard_id"),
             "status": status,
             "error": result.get("error"),
-        }, indent=2, default=str)
+        }, default=str)
     if response_mode == "standard":
         return json.dumps({
             "chart_id": result.get("chart_id"),
@@ -2180,8 +2166,8 @@ def validate_chart(
             "payload_source": result.get("payload_source"),
             "form_data_source": result.get("form_data_source"),
             "query_context_present": result.get("query_context_present"),
-        }, indent=2, default=str)
-    return json.dumps(result, indent=2, default=str)
+        }, default=str)
+    return json.dumps(result, default=str)
 
 
 @mcp.tool()
@@ -2212,7 +2198,7 @@ def validate_dashboard(
             "validated": result["validated"],
             "broken_count": len(errors),
             "broken_charts": errors,
-        }, indent=2, default=str)
+        }, default=str)
 
     if response_mode == "standard":
         summary = {
@@ -2231,8 +2217,8 @@ def validate_dashboard(
                 for item in result.get("results", [])
             ],
         }
-        return json.dumps(summary, indent=2, default=str)
-    return json.dumps(result, indent=2, default=str)
+        return json.dumps(summary, default=str)
+    return json.dumps(result, default=str)
 
 
 @mcp.tool()
@@ -2257,7 +2243,7 @@ def validate_chart_render(
             "status": result.get("status"),
             "error": result.get("error"),
             "screenshot_path": result.get("screenshot_path"),
-        }, indent=2, default=str)
+        }, default=str)
     if response_mode == "standard":
         return json.dumps({
             "chart_id": result.get("chart_id"),
@@ -2269,8 +2255,8 @@ def validate_chart_render(
             "page_errors": result.get("page_errors"),
             "chart_data_failures": result.get("chart_data_failures"),
             "screenshot_path": result.get("screenshot_path"),
-        }, indent=2, default=str)
-    return json.dumps(result, indent=2, default=str)
+        }, default=str)
+    return json.dumps(result, default=str)
 
 
 @mcp.tool()
@@ -2294,7 +2280,7 @@ def validate_dashboard_render(
             "chart_count": result.get("chart_count"),
             "validated": result.get("validated"),
             "broken_count": result.get("broken_count"),
-        }, indent=2, default=str)
+        }, default=str)
     if response_mode == "standard":
         broken_summaries: list[dict[str, Any]] = []
         for item in result.get("broken_charts", []):
@@ -2317,8 +2303,8 @@ def validate_dashboard_render(
             "validated": result.get("validated"),
             "broken_count": result.get("broken_count"),
             "broken_charts": broken_summaries,
-        }, indent=2, default=str)
-    return json.dumps(result, indent=2, default=str)
+        }, default=str)
+    return json.dumps(result, default=str)
 
 
 @mcp.tool()
@@ -2411,7 +2397,7 @@ def verify_chart_workflow(
                 int((dashboard_render or {}).get("broken_count") or 0)
                 if isinstance(dashboard_render, dict) else None
             ),
-        }, indent=2, default=str)
+        }, default=str)
 
     if response_mode == "standard":
         return json.dumps({
@@ -2452,9 +2438,9 @@ def verify_chart_workflow(
                 }
                 if isinstance(dashboard_render, dict) else None
             ),
-        }, indent=2, default=str)
+        }, default=str)
 
-    return json.dumps(result, indent=2, default=str)
+    return json.dumps(result, default=str)
 
 
 @mcp.tool()
@@ -2484,7 +2470,7 @@ def verify_dashboard_structure(
             "dangling_child_count": len(report.get("dangling_children", [])),
             "missing_id_count": len(report.get("missing_id_nodes", [])),
             "missing_type_count": len(report.get("missing_type_nodes", [])),
-        }, indent=2, default=str)
+        }, default=str)
 
     if response_mode == "standard":
         return json.dumps({
@@ -2500,13 +2486,13 @@ def verify_dashboard_structure(
             "layout_orphans": report.get("layout_orphans"),
             "scope_orphans": report.get("scope_orphans"),
             "attached_missing_layout": report.get("attached_missing_layout"),
-        }, indent=2, default=str)
+        }, default=str)
 
     return json.dumps({
         "dashboard_id": dashboard_id,
         "dashboard_title": dashboard.get("dashboard_title"),
         "structure_report": report,
-    }, indent=2, default=str)
+    }, default=str)
 
 
 @mcp.tool()
@@ -2567,7 +2553,7 @@ def verify_dashboard_workflow(
             "structure_status": structure.get("status"),
             "query_failures": query_failures,
             "render_broken_count": render_broken if include_render else None,
-        }, indent=2, default=str)
+        }, default=str)
 
     if response_mode == "standard":
         return json.dumps({
@@ -2593,7 +2579,7 @@ def verify_dashboard_workflow(
                 if include_render and isinstance(render_result, dict)
                 else None
             ),
-        }, indent=2, default=str)
+        }, default=str)
 
     return json.dumps({
         "dashboard_id": dashboard_id,
@@ -2602,7 +2588,7 @@ def verify_dashboard_workflow(
         "structure_report": structure,
         "query_validation": query_result,
         "render_validation": render_result,
-    }, indent=2, default=str)
+    }, default=str)
 
 
 @mcp.tool()
@@ -2642,7 +2628,7 @@ def capture_dashboard_template(
             "chart_count": chart_count,
             "structure_status": structure.get("status"),
             "output_path": resolved_output,
-        }, indent=2, default=str)
+        }, default=str)
 
     if response_mode == "standard":
         return json.dumps({
@@ -2657,13 +2643,12 @@ def capture_dashboard_template(
             },
             "example_charts": template.get("charts", [])[:3],
             "output_path": resolved_output,
-            "hint": "Use response_mode='full' to get the full template JSON inline.",
-        }, indent=2, default=str)
+        }, default=str)
 
     payload = dict(template)
     if resolved_output:
         payload["_saved_to"] = resolved_output
-    return json.dumps(payload, indent=2, default=str)
+    return json.dumps(payload, default=str)
 
 
 @mcp.tool()
@@ -2741,12 +2726,12 @@ def capture_golden_templates(
             "output_dir": str(target_dir),
             "saved_count": len(saved),
             "failed_count": len(failures),
-        }, indent=2, default=str)
+        }, default=str)
 
     if response_mode == "standard":
-        return json.dumps(payload, indent=2, default=str)
+        return json.dumps(payload, default=str)
 
-    return json.dumps(payload, indent=2, default=str)
+    return json.dumps(payload, default=str)
 
 
 # ===================================================================
@@ -2980,7 +2965,7 @@ def create_chart(
         payload["_params_warnings"] = params_warnings
     chart_id = _to_int(payload.get("id"))
     if chart_id is None:
-        return json.dumps(payload, indent=2, default=str)
+        return json.dumps(payload, default=str)
 
     if repair_dashboard_refs and dashboards_list:
         repairs: list[dict[str, Any]] = []
@@ -3012,7 +2997,7 @@ def create_chart(
             operation_name="creation",
             operation_past_tense="created",
         )
-    return json.dumps(payload, indent=2, default=str)
+    return json.dumps(payload, default=str)
 
 
 # ===================================================================
@@ -3257,7 +3242,7 @@ def update_chart(
             operation_name="update",
             operation_past_tense="updated",
         )
-    return json.dumps(payload, indent=2, default=str)
+    return json.dumps(payload, default=str)
 
 
 @mcp.tool()
@@ -3397,7 +3382,7 @@ def repair_dashboard_chart_refs(
         }
         if dry_run:
             payload["dry_run"] = True
-        return json.dumps(payload, indent=2, default=str)
+        return json.dumps(payload, default=str)
 
     return _do_mutation(
         tool_name="repair_dashboard_chart_refs",
@@ -3421,7 +3406,6 @@ def repair_dashboard_chart_refs(
         },
     )
 
-
 # ===================================================================
 # Tools — Snapshot
 # ===================================================================
@@ -3439,7 +3423,7 @@ def snapshot_workspace() -> str:
     ws = _get_ws()
     snap = ws.snapshot()
     _log.info("snapshot counts=%s", snap.counts)
-    return json.dumps(snap.model_dump(), indent=2, default=str)
+    return json.dumps(snap.model_dump(), default=str)
 
 
 # ===================================================================
@@ -3506,7 +3490,7 @@ def list_mutations(
         "resource_id": resource_id,
         "tool_name": tool_name,
         "entries": entries,
-    }, indent=2, default=str)
+    }, default=str)
 
 
 @mcp.tool()
@@ -3525,7 +3509,7 @@ def list_dashboard_snapshots(
             "count": 0,
             "dashboard_id": dashboard_id,
             "snapshots": [],
-        }, indent=2, default=str)
+        }, default=str)
 
     pattern = "dashboard_*.json" if dashboard_id is None else f"dashboard_{dashboard_id}_*.json"
     files = sorted(
@@ -3552,7 +3536,7 @@ def list_dashboard_snapshots(
         "count": len(records),
         "dashboard_id": dashboard_id,
         "snapshots": records,
-    }, indent=2, default=str)
+    }, default=str)
 
 
 @mcp.tool()
@@ -3617,8 +3601,6 @@ def restore_dashboard_snapshot(
             "restore_json_metadata": restore_json_metadata,
         },
     )
-
-
 # ===================================================================
 # Tools — Delete operations (opt-in via PRESET_MCP_ENABLE_DELETE)
 # ===================================================================
@@ -3757,7 +3739,7 @@ if _DELETE_ENABLED:
         """
         exports_dir = AUDIT_DIR / "exports"
         if not exports_dir.exists():
-            return json.dumps({"backups": [], "count": 0}, indent=2)
+            return json.dumps({"backups": [], "count": 0})
 
         backups: list[dict[str, Any]] = []
         for f in sorted(exports_dir.glob("*.zip")):
@@ -3782,7 +3764,7 @@ if _DELETE_ENABLED:
         return json.dumps({
             "backups": backups,
             "count": len(backups),
-        }, indent=2)
+        })
 
     @mcp.tool()
     @_handle_errors
@@ -3834,7 +3816,7 @@ if _DELETE_ENABLED:
             "export_path": export_path,
             "overwrite": overwrite,
             "success": result,
-        }, indent=2)
+        })
 
 
 # ===================================================================
@@ -3878,12 +3860,9 @@ def list_saved_queries(
         data = records
     out: dict[str, Any] = {
         "count": len(records),
-        "response_mode": response_mode,
         "data": data,
     }
-    if response_mode != "full":
-        out["hint"] = "Set response_mode='full' to see all fields."
-    return json.dumps(out, indent=2, default=str)
+    return json.dumps(out, default=str)
 
 
 @mcp.tool()
@@ -3909,10 +3888,7 @@ def get_saved_query(
         ] if k in record}
     else:
         data = record
-    out: dict[str, Any] = {"response_mode": response_mode, "data": data}
-    if response_mode != "full":
-        out["hint"] = "Set response_mode='full' to see all fields."
-    return json.dumps(out, indent=2, default=str)
+    return json.dumps({"data": data}, default=str)
 
 
 @mcp.tool()
@@ -4071,12 +4047,9 @@ def list_css_templates(
         data = records
     out: dict[str, Any] = {
         "count": len(records),
-        "response_mode": response_mode,
         "data": data,
     }
-    if response_mode != "full":
-        out["hint"] = "Set response_mode='full' to see all fields."
-    return json.dumps(out, indent=2, default=str)
+    return json.dumps(out, default=str)
 
 
 @mcp.tool()
@@ -4101,10 +4074,7 @@ def get_css_template(
         ] if k in record}
     else:
         data = record
-    out: dict[str, Any] = {"response_mode": response_mode, "data": data}
-    if response_mode != "full":
-        out["hint"] = "Set response_mode='full' to see all fields."
-    return json.dumps(out, indent=2, default=str)
+    return json.dumps({"data": data}, default=str)
 
 
 @mcp.tool()
@@ -4241,12 +4211,9 @@ def list_annotation_layers(
         data = records
     out: dict[str, Any] = {
         "count": len(records),
-        "response_mode": response_mode,
         "data": data,
     }
-    if response_mode != "full":
-        out["hint"] = "Set response_mode='full' to see all fields."
-    return json.dumps(out, indent=2, default=str)
+    return json.dumps(out, default=str)
 
 
 @mcp.tool()
@@ -4278,10 +4245,7 @@ def get_annotation_layer(
         ]
     else:
         data = {**record, "annotations": annotations}
-    out: dict[str, Any] = {"response_mode": response_mode, "data": data}
-    if response_mode != "full":
-        out["hint"] = "Set response_mode='full' to see all fields."
-    return json.dumps(out, indent=2, default=str)
+    return json.dumps({"data": data}, default=str)
 
 
 @mcp.tool()
@@ -4476,7 +4440,7 @@ def get_async_query_result(
     """
     ws = _get_ws()
     result = ws.async_query_result(query_id)
-    return json.dumps(result, indent=2, default=str)
+    return json.dumps(result, default=str)
 
 
 # ===================================================================
@@ -4503,13 +4467,12 @@ def get_embedded_dashboard(
         return json.dumps({
             "dashboard_id": dashboard_id,
             "embedded": False,
-            "hint": "Use enable_embedded_dashboard to enable embedding.",
-        }, indent=2)
+        })
     return json.dumps({
         "dashboard_id": dashboard_id,
         "embedded": True,
         "data": result,
-    }, indent=2, default=str)
+    }, default=str)
 
 
 @mcp.tool()

--- a/tests/test_new_tools.py
+++ b/tests/test_new_tools.py
@@ -89,7 +89,6 @@ def test_list_saved_queries_compact(monkeypatch) -> None:
     raw = server.list_saved_queries.fn(response_mode="compact")
     payload = json.loads(raw)
     assert payload["count"] == 2
-    assert payload["response_mode"] == "compact"
     # compact should only have id, label, db_id
     first = payload["data"][0]
     assert set(first.keys()) == {"id", "label", "db_id"}
@@ -102,14 +101,12 @@ def test_list_saved_queries_standard(monkeypatch) -> None:
     first = payload["data"][0]
     assert "sql" in first
     assert "description" in first
-    assert "hint" in payload
 
 
 def test_list_saved_queries_full(monkeypatch) -> None:
     monkeypatch.setattr(server, "_get_ws", lambda: _SavedQueryWS())
     raw = server.list_saved_queries.fn(response_mode="full")
     payload = json.loads(raw)
-    assert "hint" not in payload
     # full mode returns all original fields
     first = payload["data"][0]
     assert "changed_on" in first
@@ -153,7 +150,6 @@ def test_get_saved_query_full(monkeypatch) -> None:
     raw = server.get_saved_query.fn(query_id=2, response_mode="full")
     payload = json.loads(raw)
     assert payload["data"]["label"] == "Active users"
-    assert "hint" not in payload
 
 
 # -- create --
@@ -340,7 +336,6 @@ def test_get_css_template_full(monkeypatch) -> None:
     raw = server.get_css_template.fn(template_id=1, response_mode="full")
     payload = json.loads(raw)
     assert payload["data"]["css"] == ".dashboard { background: #1a1a1a; }"
-    assert "hint" not in payload
 
 
 # -- create --
@@ -530,7 +525,6 @@ def test_get_annotation_layer_full(monkeypatch) -> None:
     raw = server.get_annotation_layer.fn(layer_id=1, response_mode="full")
     payload = json.loads(raw)
     assert payload["data"]["annotations"] == _ANNOTATIONS
-    assert "hint" not in payload
 
 
 def test_get_annotation_layer_full_does_not_mutate_original(monkeypatch) -> None:
@@ -794,7 +788,6 @@ def test_get_embedded_dashboard_not_enabled(monkeypatch) -> None:
     raw = server.get_embedded_dashboard.fn(dashboard_id=99)
     payload = json.loads(raw)
     assert payload["embedded"] is False
-    assert "hint" in payload
 
 
 # -- enable --


### PR DESCRIPTION
## Summary
- stack the compact-response cleanup from #43 on top of #45 instead of mixing it back into `main`
- remove `indent=2` from MCP tool JSON return paths where whitespace only adds token cost
- drop echoed `response_mode` and generic `hint` strings from non-full responses
- preserve the resource-tool split from #45 without reintroducing the dashboard lifecycle/export changes moved elsewhere

## Why this is stacked
This branch depends on #45 because it also updates response payloads for the new saved-query / CSS / annotation / embedded-dashboard tools introduced there.

## Verification
- `uv run --with pytest python -m pytest`
- `uv run ruff check src/preset_py/server.py tests/test_new_tools.py`
