### PR TITLE
Add first-class dashboard lifecycle tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ claude mcp add --scope user -e PRESET_API_TOKEN=<your-token> \
   preset-mcp -- uv run --directory /path/to/preset-mcp preset-mcp
 ```
 
-## Tools (33)
+## Tools (63)
 
 ### Workspace Navigation
 
@@ -101,6 +101,14 @@ claude mcp add --scope user -e PRESET_API_TOKEN=<your-token> \
 | `update_dataset` | Change a dataset's SQL, name, or description |
 | `update_chart` | Change a chart's title, viz type, or parameters |
 | `update_dashboard` | Rename or publish/unpublish a dashboard |
+
+### Dashboard Lifecycle
+
+| Tool | Purpose |
+|------|---------|
+| `export_dashboard` | Export a dashboard ZIP bundle for backup or migration |
+| `import_dashboard` | Import a dashboard ZIP bundle and report affected dashboard IDs |
+| `delete_dashboard` | Delete a dashboard after exporting a backup ZIP |
 
 ### SQL & Query
 

--- a/src/preset_py/server.py
+++ b/src/preset_py/server.py
@@ -491,6 +491,13 @@ def _require_dashboards_exist(ws: PresetWorkspace, dashboard_ids: list[int]) -> 
         )
 
 
+def _dashboard_id_from_export_path(path: Path) -> int | None:
+    match = re.match(r"^dashboard_(\d+)_", path.name)
+    if match is None:
+        return None
+    return _to_int(match.group(1))
+
+
 _viz_type_cache: dict[str, tuple[set[str], float]] = {}
 _VIZ_TYPE_CACHE_TTL = 300  # seconds
 
@@ -3873,6 +3880,214 @@ def restore_dashboard_snapshot(
             "allow_id_mismatch": allow_id_mismatch,
         },
     )
+
+
+# ===================================================================
+# Tools — Dashboard lifecycle
+# ===================================================================
+
+
+@mcp.tool()
+@_handle_errors
+def export_dashboard(
+    dashboard_id: int,
+    output_path: str | None = None,
+) -> str:
+    """Export a dashboard ZIP bundle for backup or migration."""
+    ws = _get_ws()
+    _require_dashboards_exist(ws, [dashboard_id])
+
+    zip_bytes = ws.export_resource_zip("dashboard", [dashboard_id])
+    if output_path:
+        dest = Path(output_path).expanduser()
+    else:
+        exports_dir = AUDIT_DIR / "exports"
+        exports_dir.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        dest = exports_dir / f"dashboard_{dashboard_id}_{ts}.zip"
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(zip_bytes)
+
+    record_mutation(MutationEntry(
+        tool_name="export_dashboard",
+        resource_type="dashboard",
+        resource_id=dashboard_id,
+        action="create",
+        after_summary={
+            "export_path": str(dest),
+            "size_bytes": len(zip_bytes),
+        },
+    ))
+
+    return json.dumps({
+        "status": "exported",
+        "dashboard_id": dashboard_id,
+        "export_path": str(dest),
+        "size_bytes": len(zip_bytes),
+    }, default=str)
+
+
+@mcp.tool()
+@_handle_errors
+def import_dashboard(
+    import_path: str,
+    overwrite: bool = False,
+    repair_duplicate_layout: bool = True,
+    verify_after_import: bool = True,
+) -> str:
+    """Import a dashboard ZIP bundle and report the affected dashboard IDs."""
+    ws = _get_ws()
+    path = Path(import_path).expanduser()
+    if not path.exists():
+        raise ValueError(f"Import file not found: {import_path}")
+
+    before_dashboards = ws.dashboards()
+    before_ids = {
+        dashboard_id
+        for dashboard_id in (_to_int(d.get("id")) for d in before_dashboards)
+        if dashboard_id is not None
+    }
+
+    data = path.read_bytes()
+    success = ws.import_resource_zip("dashboard", data, overwrite=overwrite)
+
+    after_dashboards = ws.dashboards()
+    after_by_id = {
+        dashboard_id: dashboard
+        for dashboard in after_dashboards
+        for dashboard_id in [_to_int(dashboard.get("id"))]
+        if dashboard_id is not None
+    }
+    after_ids = set(after_by_id)
+    new_dashboard_ids = sorted(after_ids - before_ids)
+
+    source_dashboard_id = _dashboard_id_from_export_path(path)
+    imported_dashboard_ids = list(new_dashboard_ids)
+    if (
+        overwrite
+        and not imported_dashboard_ids
+        and source_dashboard_id is not None
+        and source_dashboard_id in after_ids
+    ):
+        imported_dashboard_ids = [source_dashboard_id]
+
+    imported_dashboards = [
+        {
+            "id": dashboard_id,
+            "dashboard_title": after_by_id[dashboard_id].get("dashboard_title"),
+        }
+        for dashboard_id in imported_dashboard_ids
+    ]
+
+    dashboard_details: dict[int, dict[str, Any]] = {}
+    repaired_dashboards: list[dict[str, Any]] = []
+    if repair_duplicate_layout:
+        for dashboard_id in imported_dashboard_ids:
+            detail = ws.dashboard_detail(dashboard_id)
+            dashboard_details[dashboard_id] = detail
+            position = _ensure_json_dict(detail.get("position_json", {}), "position_json")
+            duplicate_chart_placements = _find_duplicate_chart_placements(position)
+            if not duplicate_chart_placements:
+                continue
+
+            cleaned = _deduplicate_layout_containers(position)
+            ws.update_dashboard(
+                dashboard_id,
+                position_json=json.dumps(cleaned),
+            )
+            repaired_dashboards.append({
+                "dashboard_id": dashboard_id,
+                "duplicate_chart_count": len(duplicate_chart_placements),
+            })
+            updated_detail = dict(detail)
+            updated_detail["position_json"] = cleaned
+            dashboard_details[dashboard_id] = updated_detail
+
+    structure_checks: list[dict[str, Any]] = []
+    if verify_after_import:
+        for dashboard_id in imported_dashboard_ids:
+            detail = dashboard_details.get(dashboard_id)
+            if detail is None:
+                detail = ws.dashboard_detail(dashboard_id)
+                dashboard_details[dashboard_id] = detail
+            charts = ws.dashboard_charts(dashboard_id)
+            report = _dashboard_structure_report(
+                detail.get("position_json", {}),
+                detail.get("json_metadata", {}),
+                charts,
+            )
+            structure_checks.append({
+                "dashboard_id": dashboard_id,
+                "status": report.get("status"),
+                "duplicate_chart_count": len(report.get("duplicate_chart_placements", [])),
+                "layout_orphan_count": len(report.get("layout_orphans", [])),
+                "scope_orphan_count": len(report.get("scope_orphans", [])),
+            })
+
+    after_summary: dict[str, Any] = {
+        "import_path": str(path),
+        "overwrite": overwrite,
+        "success": success,
+        "new_dashboard_ids": new_dashboard_ids,
+    }
+    if source_dashboard_id is not None:
+        after_summary["source_dashboard_id"] = source_dashboard_id
+    if repaired_dashboards:
+        after_summary["repaired_dashboards"] = repaired_dashboards
+
+    record_mutation(MutationEntry(
+        tool_name="import_dashboard",
+        resource_type="dashboard",
+        action="create",
+        after_summary=after_summary,
+    ))
+
+    response: dict[str, Any] = {
+        "status": "imported",
+        "import_path": str(path),
+        "overwrite": overwrite,
+        "success": success,
+        "new_dashboard_ids": new_dashboard_ids,
+        "imported_dashboards": imported_dashboards,
+    }
+    if source_dashboard_id is not None:
+        response["source_dashboard_id"] = source_dashboard_id
+    if source_dashboard_id is not None and len(imported_dashboard_ids) == 1:
+        response["id_changed"] = imported_dashboard_ids[0] != source_dashboard_id
+    if repaired_dashboards:
+        response["repaired_dashboards"] = repaired_dashboards
+    if structure_checks:
+        response["structure_checks"] = structure_checks
+    if not imported_dashboard_ids:
+        response["warning"] = (
+            "Import succeeded but the imported dashboard id could not be identified "
+            "from the current workspace state."
+        )
+    return json.dumps(response, default=str)
+
+
+@mcp.tool()
+@_handle_errors
+def delete_dashboard(dashboard_id: int, dry_run: bool = False) -> str:
+    """Delete a dashboard after exporting a full backup."""
+    ws = _get_ws()
+    before = capture_before(ws, "dashboard", dashboard_id)
+    ep = export_before_delete(ws, "dashboard", dashboard_id)
+
+    return _do_mutation(
+        tool_name="delete_dashboard",
+        resource_type="dashboard",
+        action="delete",
+        fields_changed=[],
+        dry_run=dry_run,
+        execute=lambda: ws.delete_resource("dashboard", dashboard_id) or {},
+        resource_id=dashboard_id,
+        before=before,
+        export_path=ep,
+    )
+
+
 # ===================================================================
 # Tools — Delete operations (opt-in via PRESET_MCP_ENABLE_DELETE)
 # ===================================================================
@@ -3882,38 +4097,6 @@ _DELETE_ENABLED = os.environ.get("PRESET_MCP_ENABLE_DELETE", "").lower() in (
 )
 
 if _DELETE_ENABLED:
-
-    @mcp.tool()
-    @_handle_errors
-    def delete_dashboard(dashboard_id: int, dry_run: bool = False) -> str:
-        """Delete a dashboard after exporting a full backup.
-
-        A ZIP backup is saved to ~/.preset-mcp/audit/exports/ BEFORE the
-        delete proceeds.  If the export fails, the dashboard is NOT deleted.
-
-        Requires PRESET_MCP_ENABLE_DELETE=true to be available.
-
-        Args:
-            dashboard_id: ID of the dashboard to delete
-            dry_run: If True, export backup and return preview without
-                     actually deleting (default: False)
-        """
-        ws = _get_ws()
-        before = capture_before(ws, "dashboard", dashboard_id)
-        ep = export_before_delete(ws, "dashboard", dashboard_id)
-
-        return _do_mutation(
-            tool_name="delete_dashboard",
-            resource_type="dashboard",
-            action="delete",
-            fields_changed=[],
-            dry_run=dry_run,
-            execute=lambda: ws.delete_resource("dashboard", dashboard_id) or {},
-            resource_id=dashboard_id,
-            before=before,
-            export_path=ep,
-        )
-
     @mcp.tool()
     @_handle_errors
     def delete_chart(chart_id: int, dry_run: bool = False) -> str:

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -681,6 +681,152 @@ def test_restore_dashboard_snapshot_allows_mismatched_dashboard_id(monkeypatch, 
     assert ws.updated is not None
 
 
+def test_export_dashboard_writes_zip_bundle(monkeypatch, tmp_path) -> None:
+    output_path = tmp_path / "yield_dashboard.zip"
+
+    class _WS(_WorkspaceBase):
+        def export_resource_zip(self, resource_type: str, ids: list[int]):
+            assert resource_type == "dashboard"
+            assert ids == [80]
+            return b"zip-bytes"
+
+        def dashboards(self):
+            return [{"id": 80, "dashboard_title": "Yield"}]
+
+    recorded: list[object] = []
+    monkeypatch.setattr(server, "_get_ws", lambda: _WS())
+    monkeypatch.setattr(server, "record_mutation", lambda entry: recorded.append(entry))
+
+    raw = server.export_dashboard.fn(
+        dashboard_id=80,
+        output_path=str(output_path),
+    )
+    payload = json.loads(raw)
+
+    assert output_path.read_bytes() == b"zip-bytes"
+    assert payload["status"] == "exported"
+    assert payload["dashboard_id"] == 80
+    assert payload["export_path"] == str(output_path)
+    assert payload["size_bytes"] == len(b"zip-bytes")
+    assert recorded
+
+
+def test_import_dashboard_repairs_new_dashboard_and_reports_id_change(monkeypatch, tmp_path) -> None:
+    import_path = tmp_path / "dashboard_80_20260322T120000Z.zip"
+    import_path.write_bytes(b"zip-bytes")
+
+    duplicate_position = {
+        "ROOT_ID": {"id": "ROOT_ID", "type": "ROOT", "children": ["GRID_ID"]},
+        "GRID_ID": {"id": "GRID_ID", "type": "GRID", "children": ["ROW-1", "ROW-2"], "parents": ["ROOT_ID"]},
+        "ROW-1": {"id": "ROW-1", "type": "ROW", "children": ["CHART-A"], "parents": ["GRID_ID"]},
+        "ROW-2": {"id": "ROW-2", "type": "ROW", "children": ["CHART-B"], "parents": ["GRID_ID"]},
+        "CHART-A": {"id": "CHART-A", "type": "CHART", "meta": {"chartId": 101}, "children": [], "parents": ["ROW-1"]},
+        "CHART-B": {"id": "CHART-B", "type": "CHART", "meta": {"chartId": 101}, "children": [], "parents": ["ROW-2"]},
+    }
+
+    class _WS(_WorkspaceBase):
+        def __init__(self) -> None:
+            self.imported = False
+            self.updated_position_json: str | None = None
+
+        def dashboards(self):
+            if not self.imported:
+                return [{"id": 80, "dashboard_title": "Yield"}]
+            return [
+                {"id": 80, "dashboard_title": "Yield"},
+                {"id": 81, "dashboard_title": "Yield"},
+            ]
+
+        def import_resource_zip(self, resource_type: str, data: bytes, overwrite: bool = False):
+            assert resource_type == "dashboard"
+            assert data == b"zip-bytes"
+            assert overwrite is False
+            self.imported = True
+            return True
+
+        def dashboard_detail(self, dashboard_id: int):
+            if dashboard_id != 81:
+                raise AssertionError(f"unexpected dashboard id: {dashboard_id}")
+            position_json = duplicate_position
+            if self.updated_position_json is not None:
+                position_json = json.loads(self.updated_position_json)
+            return {
+                "id": dashboard_id,
+                "dashboard_title": "Yield",
+                "position_json": position_json,
+                "json_metadata": {},
+            }
+
+        def dashboard_charts(self, dashboard_id: int):
+            assert dashboard_id == 81
+            return [{"id": 101, "slice_name": "Yield Chart"}]
+
+        def update_dashboard(self, dashboard_id: int, **kwargs):
+            assert dashboard_id == 81
+            self.updated_position_json = str(kwargs["position_json"])
+            return {"id": dashboard_id}
+
+    ws = _WS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+
+    raw = server.import_dashboard.fn(
+        import_path=str(import_path),
+        overwrite=False,
+        repair_duplicate_layout=True,
+        verify_after_import=True,
+    )
+    payload = json.loads(raw)
+
+    assert payload["status"] == "imported"
+    assert payload["success"] is True
+    assert payload["source_dashboard_id"] == 80
+    assert payload["new_dashboard_ids"] == [81]
+    assert payload["imported_dashboards"] == [{"id": 81, "dashboard_title": "Yield"}]
+    assert payload["id_changed"] is True
+    assert payload["repaired_dashboards"] == [
+        {"dashboard_id": 81, "duplicate_chart_count": 1}
+    ]
+    assert payload["structure_checks"] == [
+        {
+            "dashboard_id": 81,
+            "status": "success",
+            "duplicate_chart_count": 0,
+            "layout_orphan_count": 0,
+            "scope_orphan_count": 0,
+        }
+    ]
+
+    assert ws.updated_position_json is not None
+    updated_position = json.loads(ws.updated_position_json)
+    assert updated_position["GRID_ID"]["children"] == ["ROW-1"]
+
+
+def test_delete_dashboard_is_available_without_delete_flag(monkeypatch, tmp_path) -> None:
+    export_path = tmp_path / "dashboard_80_backup.zip"
+
+    class _WS(_WorkspaceBase):
+        def __init__(self) -> None:
+            self.deleted: list[tuple[str, int]] = []
+
+        def delete_resource(self, resource_type: str, resource_id: int):
+            self.deleted.append((resource_type, resource_id))
+
+    ws = _WS()
+    monkeypatch.setattr(server, "_get_ws", lambda: ws)
+    monkeypatch.setattr(server, "capture_before", lambda ws, rt, rid: {"id": rid})
+    monkeypatch.setattr(server, "export_before_delete", lambda ws, rt, rid: export_path)
+    monkeypatch.setattr(server, "record_mutation", lambda entry: None)
+
+    raw = server.delete_dashboard.fn(dashboard_id=80, dry_run=True)
+    payload = json.loads(raw)
+
+    assert payload["dry_run"] is True
+    assert payload["dashboard_id"] == 80
+    assert payload["export_path"] == str(export_path)
+    assert ws.deleted == []
+
+
 def test_list_dashboard_snapshots_filters_by_dashboard(monkeypatch, tmp_path) -> None:
     snapshots = tmp_path / "snapshots"
     snapshots.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- add first-class `export_dashboard`, `import_dashboard`, and `delete_dashboard` MCP tools
- limit import repair/verification to the dashboards actually created or updated by the import
- add regression tests for export, import id-change reporting, duplicate-layout repair, and always-available delete

## Validation
- uv run ruff check src/preset_py/server.py tests/test_server_tools.py
- uv run --with pytest python -m pytest

Closes #42