### PR TITLE
Prepare 0.7.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## 0.7.2 - 2026-03-22
+
+### Added
+- First-class dashboard lifecycle tools:
+  - `export_dashboard`
+  - `import_dashboard`
+  - `delete_dashboard`
+- Added Preset resource-management tools for saved queries, CSS templates,
+  annotation layers, async query inspection, and embedded dashboards.
+
+### Fixed
+- Dashboard-import repair now only mutates dashboards created or updated by
+  the import, and dashboard structure checks now flag duplicate chart
+  placements more reliably.
+- `restore_dashboard_snapshot` can now target recreated dashboards whose ids
+  changed after replacement or re-import.
+- Preset resource API helpers now surface non-2xx failures instead of
+  silently returning success-shaped payloads.
+- Fixed annotation-layer mutation handling and expanded regression coverage for
+  the new resource tools.
+
+### Improved
+- MCP tool responses now use compact JSON payloads and omit repeated
+  `response_mode` / hint echoes to reduce token overhead.
+- The packaged MCP surface now exposes 63 tools.
+
+## 0.7.1 - 2026-03-17
+
+### Fixed
+- `create_chart` / `update_chart` now preserve the synthetic `query_context`
+  metadata needed for downstream validation and follow-up inspection.
+- Reduced redundant Preset API calls with batching/caching optimizations in
+  chart and dataset operations.
+
+### Quality
+- Added regression coverage for query-context persistence and the API-call
+  reduction paths introduced in the `0.7.1` patch release.
+
 ## 0.7.0 - 2026-03-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ claude mcp add --scope user -e PRESET_API_TOKEN=<your-token> \
 
 ```bash
 claude mcp list
-# Should show: preset-mcp  ... 33 tools
+# Should show: preset-mcp  ... 63 tools
 ```
 
 Then in a Claude Code session, try:

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -74,7 +74,7 @@ claude mcp list
 You should see:
 
 ```
-preset-mcp · 33 tools
+preset-mcp · 63 tools
 ```
 
 If it shows `failed`, check:
@@ -174,4 +174,4 @@ Either set `PRESET_WORKSPACE` in your config (Step 3) or tell Claude:
 
 ### Tools not appearing
 
-Restart Claude Code after adding the MCP. Check `claude mcp list` shows 33 tools.
+Restart Claude Code after adding the MCP. Check `claude mcp list` shows 63 tools.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "preset-mcp"
-version = "0.7.1"
+version = "0.7.2"
 description = "MCP server for Preset (Superset) — manage dashboards, charts, and datasets from Claude Code and other LLM agents"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1399,7 +1399,7 @@ wheels = [
 
 [[package]]
 name = "preset-mcp"
-version = "0.7.0"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
- bump the package version from `0.7.1` to `0.7.2`
- add changelog entries for `0.7.1` and `0.7.2`
- fix stale tool-count docs so the shipped README/setup guide reflect the current 63-tool surface

## Validation
- uv run ruff check src/preset_py tests
- uv run --with pytest python -m pytest
- uv build
- uv run --with twine twine check dist/*
- uv tool install --from dist/preset_mcp-0.7.2-py3-none-any.whl preset-mcp --with preset-cli --with fastmcp --with sqlglot --with pydantic