### PR TITLE
[codex] Add audit history tools and workflow planning layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ claude mcp add --scope user -e PRESET_API_TOKEN=<your-token> \
 
 ```bash
 claude mcp list
-# Should show: preset-mcp  ... 63 tools
+# Should show: preset-mcp  ... 66 tools
 ```
 
 Then in a Claude Code session, try:
@@ -63,7 +63,7 @@ claude mcp add --scope user -e PRESET_API_TOKEN=<your-token> \
   preset-mcp -- uv run --directory /path/to/preset-mcp preset-mcp
 ```
 
-## Tools (63)
+## Tools (66)
 
 ### Workspace Navigation
 
@@ -84,6 +84,9 @@ claude mcp add --scope user -e PRESET_API_TOKEN=<your-token> \
 | `get_dataset` | Get detail for a single dataset (columns, metrics, SQL) |
 | `list_databases` | List database connections |
 | `get_database` | Get detail for a single database connection |
+| `list_logs` | List official audit logs when the workspace exposes them |
+| `get_log` | Get detail for a single official audit-log record |
+| `get_dashboard_history` | Combine official dashboard audit logs with local MCP history |
 | `workspace_catalog` | Relationship-aware topology map |
 
 ### Create
@@ -129,6 +132,9 @@ claude mcp add --scope user -e PRESET_API_TOKEN=<your-token> \
 | `verify_dashboard_structure` | Validate dashboard layout graph and chart references |
 | `verify_dashboard_workflow` | One-shot dashboard structure/query/render verification |
 | `repair_dashboard_chart_refs` | Repair stale dashboard chart ID references |
+| `list_logs` | Read official audit logs from `/api/v1/log/` when available |
+| `get_log` | Inspect a single official audit-log record |
+| `get_dashboard_history` | Best-effort dashboard history from official logs + local snapshots |
 | `list_mutations` | Inspect local mutation audit journal entries |
 | `list_dashboard_snapshots` | List local pre-mutation dashboard snapshots |
 | `restore_dashboard_snapshot` | Restore dashboard layout/settings from local snapshot |
@@ -201,6 +207,17 @@ JSON logs on stderr (stdout is reserved for the STDIO transport):
 ```json
 {"ts":"2025-02-11 12:00:00","level":"INFO","msg":"tool=list_dashboards status=ok duration_ms=234"}
 ```
+
+### Official Audit Logs
+
+`list_logs`, `get_log`, and `get_dashboard_history` wrap Superset's
+official `/api/v1/log/` endpoint when the workspace exposes it. Some
+Preset deployments return `404 Not found` for that route or restrict it
+to specific plans/roles. In those environments:
+
+- `list_logs` / `get_log` return a structured error
+- `get_dashboard_history` reports official-log unavailability but still
+  returns MCP-local mutation journal and snapshot history when present
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ claude mcp add --scope user -e PRESET_API_TOKEN=<your-token> \
 
 ```bash
 claude mcp list
-# Should show: preset-mcp  ... 66 tools
+# Should show: preset-mcp  ... 68 tools
 ```
 
 Then in a Claude Code session, try:
@@ -63,7 +63,7 @@ claude mcp add --scope user -e PRESET_API_TOKEN=<your-token> \
   preset-mcp -- uv run --directory /path/to/preset-mcp preset-mcp
 ```
 
-## Tools (66)
+## Tools (68)
 
 ### Workspace Navigation
 
@@ -104,6 +104,13 @@ claude mcp add --scope user -e PRESET_API_TOKEN=<your-token> \
 | `update_dataset` | Change a dataset's SQL, name, or description |
 | `update_chart` | Change a chart's title, viz type, or parameters |
 | `update_dashboard` | Rename or publish/unpublish a dashboard |
+
+### Workflow
+
+| Tool | Purpose |
+|------|---------|
+| `plan_dashboard_changes` | Return a plan-first workflow diff for supported dashboard edits |
+| `apply_dashboard_plan` | Apply a previously planned workflow change set |
 
 ### Dashboard Lifecycle
 
@@ -155,6 +162,16 @@ The intended workflow pairs preset-mcp with a data warehouse MCP (like [igloo-mc
 6. create_chart + create_dashboard     (preset-mcp) — build the viz
 7. update_dataset / update_chart       (preset-mcp) — iterate
 ```
+
+## Workflow Layer
+
+The workflow layer is additive and plan-first. It does not replace the existing low-level Preset tools.
+
+1. Call `plan_dashboard_changes` or a future convenience `plan_*` workflow helper.
+2. Inspect the returned plan payload and structural changes.
+3. Call `apply_dashboard_plan` to mutate the target.
+
+Local mode uses exported YAML as the canonical authoring artifact. Flat dashboards remain first-class, and tabs are only created through explicit tab operations or tabbed layout presets.
 
 ## Features
 

--- a/docs/superpowers/specs/2026-04-03-preset-mcp-workflow-layer-design.md
+++ b/docs/superpowers/specs/2026-04-03-preset-mcp-workflow-layer-design.md
@@ -1,0 +1,522 @@
+# Preset MCP Workflow Layer Design
+
+Date: 2026-04-03
+Status: Proposed
+Scope: Additive workflow layer for dashboard authoring in `preset-mcp`
+
+## Goal
+
+Add a higher-level workflow layer on top of the existing `preset-mcp` tool surface so dashboard authoring is safer and more ergonomic, especially for:
+
+- tab management
+- chart placement and movement
+- reusable layout presets
+- reusable chart presets
+- local/offline editing against exported Preset YAML
+
+The workflow layer must preserve the current low-level tools and safety behavior. It should not replace `create_chart`, `update_chart`, `update_dashboard`, repair tools, or validation tools.
+
+## Problem Statement
+
+`preset-mcp` already has strong low-level primitives:
+
+- chart, dataset, and dashboard CRUD
+- layout validation
+- repair tools for broken dashboard references
+- chart and dashboard validation
+- mutation snapshots and audit history
+- reusable dashboard template capture
+
+The current gap is authoring ergonomics.
+
+Today:
+
+- tabs are only manipulable through raw `position_json` / `json_metadata`
+- chart defaults are helpful but too limited to serve as a reusable preset system
+- live editing and local export editing are separate mental models
+- common dashboard tasks require understanding Superset layout internals instead of expressing intent
+
+The result is that `preset-mcp` is safe and capable, but cumbersome for higher-level dashboard-building workflows.
+
+## Design Priorities
+
+Priority order:
+
+1. Safety
+2. Portability
+3. Full dashboard authoring coverage
+
+Additional requirements:
+
+- additive only: existing tool behavior must remain unchanged
+- offline/local mode must be first-class
+- flat dashboards must work as well as tabbed dashboards
+- plan/apply should be mandatory by default for high-level workflow tools
+
+## Non-Goals
+
+This design does not propose:
+
+- replacing the current low-level tool surface
+- making tabs mandatory
+- inventing a brand new dashboard spec format
+- weakening strict validation behavior in existing low-level chart tools
+- changing the current return contracts of existing tools
+
+## Current State Summary
+
+The current architecture has three effective layers:
+
+1. Thin client wrappers over Preset/Superset APIs
+2. Server-side workflow and safety semantics
+3. Safety and audit helpers
+
+Important existing strengths:
+
+- `create_chart` already applies sensible defaults for some chart types
+- `update_chart` is intentionally strict about `params_json`
+- `update_dashboard` validates layout structure and blocks destructive wipes by default
+- repair and verification tools already exist for layout and chart integrity
+- snapshots and audit logs already exist for pre-mutation safety and recovery
+
+Important existing weaknesses:
+
+- no first-class tab operations
+- no first-class chart/layout preset registry
+- no unified live/offline workflow authoring layer
+- no intent-based planning surface for common dashboard changes
+
+## Source Of Truth Model
+
+The workflow layer should be YAML-first.
+
+### Canonical authoring artifact
+
+Exported Preset YAML is the canonical offline artifact.
+
+Reasons:
+
+- it matches the files already stored in the repo
+- it is easier to review in git than large JSON blobs
+- it avoids introducing another local dashboard representation for users to learn
+
+### Minimal normalization
+
+The implementation may use minimal internal normalization as a private helper, but not a heavyweight typed domain model that becomes a second conceptual source of truth.
+
+Minimal normalization should only cover unsafe or repetitive operations such as:
+
+- locating layout nodes
+- resolving chart references
+- managing `TAB` / `TABS` nodes
+- syncing layout and metadata chart references
+- expanding chart presets into valid params payloads
+
+This keeps the user-facing model simple while still reducing brittle string-level YAML manipulation inside the implementation.
+
+### Live mode
+
+In live mode, the workflow layer should fetch the current dashboard/chart state from Preset and convert it into a YAML-shaped working document for planning and apply.
+
+This preserves one planning model:
+
+- local YAML path
+- live dashboard converted into YAML-shaped working state
+
+## High-Level Architecture
+
+The workflow layer should sit above the current low-level tools.
+
+### Existing low-level tools remain intact
+
+The following stay unchanged and continue to be usable directly:
+
+- chart create/update tools
+- dashboard update tools
+- repair tools
+- verification tools
+- snapshot and audit behavior
+
+### New workflow planner
+
+Add a planner/reconciler responsible for:
+
+- loading a target dashboard from YAML or live Preset
+- computing a structured plan for requested operations
+- validating structural implications before apply
+- applying the approved plan through the appropriate adapter
+
+### Adapters
+
+Add two thin adapters:
+
+- `LivePresetAdapter`
+  - reads from `PresetWorkspace`
+  - applies changes using existing low-level tools and helpers
+
+- `YamlExportAdapter`
+  - reads exported dashboard/chart/dataset YAML
+  - writes YAML patches back to those files
+
+### Preset registries
+
+Store presets as YAML:
+
+- layout presets
+- chart presets
+
+These should live in repo-managed files so they are reviewable and portable.
+
+## Dashboard Mode Invariant
+
+The workflow layer must support both dashboard modes as first-class:
+
+- flat dashboards
+- tabbed dashboards
+
+### Rules
+
+- flat dashboards are not a degraded case
+- tabs must never be created implicitly
+- a chart operation on a flat dashboard must remain flat unless the user explicitly requested tab creation or a tabbed preset
+- mode transitions must be explicit in plan output:
+  - `flat -> tabbed`
+  - `tabbed -> flat`
+
+### Layout preset mode
+
+Each layout preset should declare one of:
+
+- `flat`
+- `tabbed`
+- `adaptive`
+
+`adaptive` means preserve the current dashboard mode unless the requested workflow explicitly changes it.
+
+## Workflow Surface
+
+V1 should expose a small additive set of plan-first tools.
+
+### Core workflow tools
+
+- `load_dashboard_document`
+- `plan_dashboard_changes`
+- `apply_dashboard_plan`
+
+These form the foundation. Convenience tools should compile into the same plan shape.
+
+### Convenience planning tools
+
+- `plan_add_tab`
+- `plan_rename_tab`
+- `plan_remove_tab`
+- `plan_reorder_tabs`
+- `plan_move_chart_to_tab`
+- `plan_move_chart`
+- `plan_add_chart_to_dashboard`
+- `plan_remove_chart_from_dashboard`
+- `plan_apply_layout_preset`
+- `plan_create_chart_with_preset`
+- `plan_update_chart_with_preset`
+
+These tools should not mutate by default. They should return plans that are later applied through `apply_dashboard_plan`.
+
+## Plan / Apply Model
+
+High-level workflow operations should default to mandatory plan-then-apply.
+
+### Plan
+
+The plan result should include:
+
+- target mode: live or YAML path
+- operation summary
+- structural changes
+- file or resource targets
+- warnings
+- explicit mode transition notices
+- post-apply validation steps
+
+### Apply
+
+`apply_dashboard_plan` should:
+
+- verify the plan still matches the current target state closely enough to apply safely
+- execute through the live or YAML adapter
+- reuse existing snapshot and audit mechanisms for live mutation
+- return an applied summary plus validation results
+
+## Tab Management Semantics
+
+Tabs should become a first-class concept in the workflow layer.
+
+### Add tab
+
+`plan_add_tab` should:
+
+- create `TABS` if explicitly required and missing
+- create a `TAB` node
+- attach rows under the new tab
+- update any affected chart/layout bookkeeping
+
+### Rename tab
+
+`plan_rename_tab` should:
+
+- modify only the tab label metadata
+- avoid unrelated layout churn
+
+### Remove tab
+
+`plan_remove_tab` should require a strategy when the tab is not empty:
+
+- block
+- move contents to another tab
+- flatten contents into the root grid
+- remove the tab and prune now-unreachable nodes
+
+### Move chart to tab
+
+`plan_move_chart_to_tab` should:
+
+- locate the chart’s current layout placement
+- remove it from the old placement
+- insert it into the target tab using layout preset rules
+- update chart scope bookkeeping as needed
+
+### Reorder tabs
+
+`plan_reorder_tabs` should only reorder tab children and leave contained rows/charts untouched.
+
+## Layout Presets
+
+Layout presets should define placement behavior and structure rules, not hardcode specific charts.
+
+Expected concerns:
+
+- dashboard mode
+- charts per row
+- chart width allocation
+- row generation behavior
+- insertion order
+- spacing rules
+- empty-tab behavior
+
+### Example
+
+`flat_two_up`
+
+- mode: `flat`
+- max charts per row: `2`
+- chart width: `6`
+- insertion order: left-to-right, top-to-bottom
+
+`tabbed_two_up`
+
+- mode: `tabbed`
+- same placement rules as above, but scoped inside each tab
+
+## Chart Presets
+
+Chart presets should reduce repetitive `params_json` authoring for common styles.
+
+They should expand into valid full params payloads before invoking existing chart tools.
+
+### Example starter presets
+
+`timeseries_default`
+
+- x-axis title margin: `30`
+- y-axis title margin: `50`
+- legend at top
+- rich tooltip enabled
+
+`pie_default`
+
+- legend at top
+- labels outside
+- standard smart number formatting
+
+`table_default`
+
+- standard row limit
+- common ordering defaults
+
+### Important constraint
+
+Existing low-level strictness stays in place.
+
+The workflow layer should make common edits easier by generating complete valid chart params, not by weakening strict validation semantics in `update_chart`.
+
+## Local / Offline Workflow
+
+Offline workflow should operate directly on exported YAML.
+
+### Primary behavior
+
+- load dashboard YAML
+- compute plan against YAML
+- write YAML patches on apply
+
+### Benefits
+
+- reviewable in git
+- works before touching live Preset
+- supports experimentation in repo-backed “sandbox” dashboards
+
+### Design consequence
+
+Plan output for offline mode should reference YAML file paths and changed sections, not abstract hidden identifiers whenever possible.
+
+## Live Workflow
+
+Live apply should compile into the current low-level tools rather than bypass them.
+
+Examples:
+
+- chart creation flows into `create_chart`
+- chart preset updates flow into `update_chart`
+- layout changes flow into `update_dashboard`
+- post-apply verification reuses existing dashboard/chart validation tools
+
+This preserves the current safety posture and reduces the risk of introducing a second mutation stack.
+
+## Safety Rules
+
+The workflow layer must preserve or improve the current safety guarantees.
+
+### Required rules
+
+- no direct mutation in high-level workflow tools without an explicit apply step
+- no implicit tab creation
+- no implicit flattening of tabbed dashboards
+- no destructive layout wipe without explicit override
+- layout and metadata updates must stay synchronized
+- plans must surface major structural changes prominently
+
+### Existing safety mechanisms to reuse
+
+- pre-mutation snapshots
+- mutation audit journal
+- layout validation
+- repair tools
+- dashboard verification tools
+
+## Compatibility Rules
+
+Compatibility requirements are strict.
+
+- existing tools keep their current signatures and semantics
+- existing responses remain unchanged
+- the workflow layer is additive only
+- low-level tools remain the escape hatch for advanced users
+
+The workflow layer must not create a devx regression for users who already know the current tool surface.
+
+## Testing Strategy
+
+Testing should cover both safety and portability.
+
+### Offline tests
+
+- YAML fixture-based plan generation
+- YAML apply roundtrip tests
+- no-op stability tests
+- flat dashboard fixture coverage
+- tabbed dashboard fixture coverage
+
+### Live-like tests
+
+- plan compilation into existing low-level tool calls
+- mode transition planning
+- chart movement planning
+- chart preset expansion into valid full params
+
+### Regression coverage
+
+Preserve and extend coverage around:
+
+- destructive empty-layout wipes
+- dangling layout children
+- duplicate chart placements
+- stale chart references
+- datasource preservation during chart updates
+- validation timeouts and partial success behavior
+
+## Rollout Plan
+
+### Phase 1
+
+Add workflow planning substrate only:
+
+- YAML loaders/writers
+- minimal normalization helpers
+- plan generation without mutation
+
+### Phase 2
+
+Add offline/local plan/apply:
+
+- tab operations
+- chart movement
+- layout presets
+- chart presets
+
+### Phase 3
+
+Add live apply through existing primitives:
+
+- compile workflow plan into current chart/dashboard tools
+- reuse snapshots, audit, repair, and validation
+
+### Phase 4
+
+Ship initial preset registry:
+
+- `flat_two_up`
+- `tabbed_two_up`
+- `timeseries_default`
+- `pie_default`
+- `table_default`
+
+### Phase 5
+
+Add convenience MCP tools over the planner.
+
+## Suggested File Layout
+
+Suggested additions:
+
+- `src/preset_py/workflow/`
+- `src/preset_py/workflow/planner.py`
+- `src/preset_py/workflow/yaml_adapter.py`
+- `src/preset_py/workflow/live_adapter.py`
+- `src/preset_py/workflow/layout_ops.py`
+- `src/preset_py/workflow/chart_presets.py`
+- `src/preset_py/workflow/layout_presets.py`
+
+Suggested tests:
+
+- `tests/test_workflow_yaml.py`
+- `tests/test_workflow_live.py`
+- `tests/fixtures/workflow/`
+
+Suggested preset storage:
+
+- `src/preset_py/presets/layouts/*.yaml`
+- `src/preset_py/presets/charts/*.yaml`
+
+## Success Criteria
+
+V1 is successful if:
+
+- flat dashboards work without any tab assumptions
+- tabbed dashboards can be managed without hand-editing raw `position_json`
+- offline/local YAML editing is first-class
+- live workflow apply reuses existing safety rails
+- chart and layout presets materially reduce repetitive parameter authoring
+- existing low-level users do not lose any current capability
+
+## Final Recommendation
+
+Proceed with an additive, YAML-first workflow layer built around mandatory plan/apply, first-class support for both flat and tabbed dashboards, and preset-driven dashboard authoring that compiles into the current safe mutation primitives.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "preset-cli",
     "pydantic>=2.0",
     "fastmcp>=2.0",
+    "PyYAML>=6.0",
     "sqlglot>=26.0",
 ]
 

--- a/src/preset_py/client.py
+++ b/src/preset_py/client.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import pandas as pd
+import prison
 from yarl import URL
 
 from preset_cli.auth.lib import get_access_token
@@ -650,6 +651,21 @@ def _api_error_message(body: Any) -> str:
     return " | ".join(dict.fromkeys(messages))
 
 
+def _audit_log_endpoint_error(operation: str, message: str) -> ValueError:
+    """Return a stable error when official audit-log endpoints are unavailable."""
+    lowered = message.lower()
+    if "not found" in lowered or "404" in lowered:
+        return ValueError(
+            f"{operation} failed: the official audit-log endpoint is unavailable "
+            "in this Preset/Superset deployment or for the current role."
+        )
+    if "forbidden" in lowered or "401" in lowered or "403" in lowered:
+        return ValueError(
+            f"{operation} failed: access to the official audit-log endpoint was denied."
+        )
+    return ValueError(f"{operation} failed: {message}")
+
+
 def _infer_dataset_time_column(dataset: dict[str, Any]) -> str | None:
     """Infer a default datetime column when exactly one exists."""
     raw_columns = dataset.get("columns")
@@ -933,6 +949,39 @@ class PresetWorkspace:
 
     def databases(self, **filters: Any) -> list[dict[str, Any]]:
         return self._client.get_databases(**filters)
+
+    def logs(
+        self,
+        *,
+        page: int = 0,
+        page_size: int = 50,
+        order_column: str = "dttm",
+        order_direction: Literal["asc", "desc"] = "desc",
+    ) -> dict[str, Any]:
+        """Return one page of official audit logs, if the endpoint is available."""
+        query = prison.dumps({
+            "page": page,
+            "page_size": page_size,
+            "order_column": order_column,
+            "order_direction": order_direction,
+        })
+        endpoint = str(self._client.baseurl / "api/v1" / "log" / "" % {"q": query})
+        try:
+            return self._request_json("get", endpoint, "List audit logs")
+        except ValueError as exc:
+            raise _audit_log_endpoint_error("List audit logs", str(exc)) from exc
+
+    def log_detail(self, log_id: int) -> dict[str, Any]:
+        """Fetch a single official audit-log record by id."""
+        endpoint = str(self._client.baseurl / "api/v1" / "log" / str(log_id))
+        try:
+            payload = self._request_json("get", endpoint, f"Get audit log {log_id}")
+        except ValueError as exc:
+            raise _audit_log_endpoint_error("Get audit log", str(exc)) from exc
+        result = payload.get("result")
+        if not isinstance(result, dict):
+            raise ValueError("Get audit log failed: malformed API response.")
+        return result
 
     def get_resource(self, resource_type: str, resource_id: int) -> dict[str, Any]:
         """Fetch a single resource by type and ID."""

--- a/src/preset_py/presets/charts/pie_default.yaml
+++ b/src/preset_py/presets/charts/pie_default.yaml
@@ -1,0 +1,4 @@
+name: pie_default
+legend_orientation: right
+rich_tooltip: true
+show_legend: true

--- a/src/preset_py/presets/charts/pie_default.yaml
+++ b/src/preset_py/presets/charts/pie_default.yaml
@@ -1,4 +1,6 @@
 name: pie_default
-legend_orientation: right
+legend_orientation: top
+labels_outside: true
+number_format: SMART_NUMBER
 rich_tooltip: true
 show_legend: true

--- a/src/preset_py/presets/charts/table_default.yaml
+++ b/src/preset_py/presets/charts/table_default.yaml
@@ -1,0 +1,4 @@
+name: table_default
+page_length: 25
+show_row_numbers: true
+sticky_pagination: true

--- a/src/preset_py/presets/charts/table_default.yaml
+++ b/src/preset_py/presets/charts/table_default.yaml
@@ -1,4 +1,7 @@
 name: table_default
-page_length: 25
+row_limit: 1000
+server_page_length: 25
+order_by_cols: []
+order_desc: true
 show_row_numbers: true
 sticky_pagination: true

--- a/src/preset_py/presets/charts/timeseries_default.yaml
+++ b/src/preset_py/presets/charts/timeseries_default.yaml
@@ -1,0 +1,5 @@
+name: timeseries_default
+x_axis_title_margin: 30
+y_axis_title_margin: 50
+legend_orientation: top
+rich_tooltip: true

--- a/src/preset_py/presets/layouts/flat_two_up.yaml
+++ b/src/preset_py/presets/layouts/flat_two_up.yaml
@@ -1,0 +1,5 @@
+name: flat_two_up
+mode: flat
+charts_per_row: 2
+chart_width: 6
+insertion_order: row_major

--- a/src/preset_py/presets/layouts/tabbed_two_up.yaml
+++ b/src/preset_py/presets/layouts/tabbed_two_up.yaml
@@ -1,0 +1,5 @@
+name: tabbed_two_up
+mode: tabbed
+charts_per_row: 2
+chart_width: 6
+insertion_order: row_major

--- a/src/preset_py/server.py
+++ b/src/preset_py/server.py
@@ -5246,6 +5246,53 @@ def disable_embedded_dashboard(
 
 
 # ===================================================================
+# Tools — Workflow Planning
+# ===================================================================
+
+
+@mcp.tool()
+@_handle_errors
+def plan_dashboard_changes(
+    dashboard_id: int | None = None,
+    yaml_path: str | None = None,
+    operations: str = "[]",
+) -> str:
+    """Plan dashboard workflow changes without applying them."""
+    requested = json.loads(operations)
+    if not isinstance(requested, list) or not requested:
+        raise ValueError("Provide at least one workflow operation.")
+
+    if yaml_path:
+        first = requested[0]
+        if isinstance(first, dict) and first.get("kind") == "add_tab":
+            from preset_py.workflow.planner import plan_add_tab
+
+            payload = plan_add_tab(
+                yaml_path=Path(yaml_path),
+                tab_name=str(first["tab_name"]),
+            )
+            return json.dumps(payload, default=str)
+        raise ValueError("Unsupported YAML workflow operation set.")
+
+    if dashboard_id is not None:
+        raise ValueError("Live dashboard workflow planning is not implemented yet.")
+
+    raise ValueError("Provide either yaml_path or dashboard_id.")
+
+
+@mcp.tool()
+@_handle_errors
+def apply_dashboard_plan(plan_json: str) -> str:
+    """Apply a previously planned workflow change set."""
+    from preset_py.workflow.planner import apply_workflow_plan
+
+    plan = json.loads(plan_json)
+    if not isinstance(plan, dict):
+        raise ValueError("plan_json must decode to an object.")
+    return json.dumps(apply_workflow_plan(plan), default=str)
+
+
+# ===================================================================
 # Entry point
 # ===================================================================
 

--- a/src/preset_py/server.py
+++ b/src/preset_py/server.py
@@ -100,6 +100,7 @@ _COMPACT: dict[str, list[str]] = {
     "chart": ["id", "slice_name", "viz_type"],
     "dataset": ["id", "table_name", "schema"],
     "database": ["id", "database_name", "backend"],
+    "log": ["id", "action", "dttm"],
 }
 
 _STANDARD: dict[str, list[str]] = {
@@ -119,6 +120,10 @@ _STANDARD: dict[str, list[str]] = {
         "id", "database_name", "backend", "expose_in_sqllab",
         "allow_dml",
     ],
+    "log": [
+        "id", "action", "dttm", "user", "user_id", "path",
+        "dashboard_id", "slice_id", "dashboard_title",
+    ],
 }
 
 # ---------------------------------------------------------------------------
@@ -133,6 +138,7 @@ _DETAIL_COMPACT: dict[str, list[str]] = {
     "chart": ["id", "slice_name", "viz_type", "datasource_id", "datasource_type"],
     "dataset": ["id", "table_name", "schema", "database", "kind"],
     "database": ["id", "database_name", "backend"],
+    "log": ["id", "action", "dttm"],
 }
 
 _DETAIL_STANDARD: dict[str, list[str]] = {
@@ -153,6 +159,10 @@ _DETAIL_STANDARD: dict[str, list[str]] = {
     "database": [
         "id", "database_name", "backend", "expose_in_sqllab",
         "allow_dml", "configuration_method",
+    ],
+    "log": [
+        "id", "action", "dttm", "user", "user_id", "path",
+        "dashboard_id", "slice_id", "dashboard_title", "json", "referrer",
     ],
 }
 
@@ -253,6 +263,15 @@ def _format_sql(
     return json.dumps(out, default=str)
 
 
+def _format_log_records(records: list[dict[str, Any]], mode: ResponseMode) -> list[dict[str, Any]]:
+    """Apply progressive disclosure to official audit-log records."""
+    if mode == "compact":
+        return _pick(records, _COMPACT["log"])
+    if mode == "standard":
+        return _pick(records, _STANDARD["log"])
+    return records
+
+
 # ---------------------------------------------------------------------------
 # Client-side name filter
 # ---------------------------------------------------------------------------
@@ -270,6 +289,88 @@ def _filter_by_name(records: list[dict], resource: str, name_contains: str) -> l
     key = _NAME_KEYS.get(resource, "name")
     needle = name_contains.lower()
     return [r for r in records if needle in str(r.get(key, "")).lower()]
+
+
+def _record_contains_exact_int(value: Any, target: int) -> bool:
+    """Recursively search a payload for an exact integer match."""
+    if value is None or isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return value == target
+    if isinstance(value, str):
+        return re.search(rf"(?<!\d){target}(?!\d)", value) is not None
+    if isinstance(value, list):
+        return any(_record_contains_exact_int(item, target) for item in value)
+    if isinstance(value, dict):
+        return any(_record_contains_exact_int(item, target) for item in value.values())
+    return False
+
+
+def _record_contains_text(value: Any, needle: str) -> bool:
+    """Recursively search a payload for a case-insensitive text match."""
+    lowered = needle.lower()
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return lowered in value.lower()
+    if isinstance(value, (int, float)):
+        return lowered in str(value).lower()
+    if isinstance(value, list):
+        return any(_record_contains_text(item, needle) for item in value)
+    if isinstance(value, dict):
+        return any(
+            lowered in str(key).lower() or _record_contains_text(item, needle)
+            for key, item in value.items()
+        )
+    return False
+
+
+def _log_matches_dashboard(record: dict[str, Any], dashboard_id: int) -> bool:
+    """Best-effort match for dashboard-related audit-log records."""
+    direct_keys = (
+        "dashboard_id", "dashboard", "dashboard_title",
+        "item_id", "object_id", "target_id",
+    )
+    for key in direct_keys:
+        if key in record and _record_contains_exact_int(record.get(key), dashboard_id):
+            return True
+
+    if not _record_contains_text(record, "dashboard"):
+        return False
+    return _record_contains_exact_int(record, dashboard_id)
+
+
+def _list_dashboard_snapshot_records(
+    dashboard_id: int | None = None,
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Return local dashboard snapshot metadata records."""
+    snap_dir = AUDIT_DIR / "snapshots"
+    if not snap_dir.exists():
+        return []
+
+    pattern = "dashboard_*.json" if dashboard_id is None else f"dashboard_{dashboard_id}_*.json"
+    files = sorted(
+        snap_dir.glob(pattern),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+    records: list[dict[str, Any]] = []
+    for snap in files[:limit]:
+        stem_parts = snap.stem.split("_")
+        snap_dashboard_id = _to_int(stem_parts[1]) if len(stem_parts) >= 3 else None
+        timestamp_token = stem_parts[2] if len(stem_parts) >= 3 else None
+        records.append({
+            "snapshot_path": str(snap),
+            "dashboard_id": snap_dashboard_id,
+            "timestamp_token": timestamp_token,
+            "size_bytes": snap.stat().st_size,
+            "modified_at": datetime.fromtimestamp(
+                snap.stat().st_mtime, tz=timezone.utc
+            ).isoformat(),
+        })
+    return records
 
 
 # ---------------------------------------------------------------------------
@@ -1939,6 +2040,173 @@ def list_databases(
         raw = _filter_by_name(raw, "database", name_contains)
     _log.info("list_databases count=%d mode=%s", len(raw), response_mode)
     return _format_list(raw, "database", response_mode)
+
+
+@mcp.tool()
+@_handle_errors
+def list_logs(
+    response_mode: ResponseMode = "standard",
+    action: str | None = None,
+    dashboard_id: int | None = None,
+    user_id: int | None = None,
+    text_contains: str | None = None,
+    page: int = 0,
+    limit: int = 50,
+) -> str:
+    """List official audit logs from Preset/Superset when available.
+
+    This wraps the workspace's `/api/v1/log/` endpoint. Some Preset
+    deployments do not expose this route or restrict it to certain plans/roles.
+
+    Args:
+        response_mode: 'compact', 'standard', or 'full'. Default: standard.
+        action: Case-insensitive substring filter on the log action.
+        dashboard_id: Best-effort filter for dashboard-related log entries.
+        user_id: Exact-match filter for user IDs found in the log payload.
+        text_contains: Case-insensitive substring filter across the record.
+        page: Zero-based results page to fetch from the API.
+        limit: Page size / max records fetched from the API. Default: 50.
+    """
+    if page < 0:
+        raise ValueError("page must be >= 0.")
+    if limit < 1 or limit > 100:
+        raise ValueError("limit must be between 1 and 100.")
+
+    ws = _get_ws()
+    payload = ws.logs(page=page, page_size=limit)
+    records = payload.get("result", [])
+    if not isinstance(records, list):
+        raise ValueError("List audit logs failed: malformed API response.")
+
+    if action:
+        needle = action.lower()
+        records = [
+            r for r in records
+            if needle in str(r.get("action", "")).lower()
+        ]
+    if dashboard_id is not None:
+        records = [r for r in records if _log_matches_dashboard(r, dashboard_id)]
+    if user_id is not None:
+        records = [r for r in records if _record_contains_exact_int(r, user_id)]
+    if text_contains:
+        records = [r for r in records if _record_contains_text(r, text_contains)]
+
+    out: dict[str, Any] = {
+        "count": len(records),
+        "page": page,
+        "limit": limit,
+        "data": _format_log_records(records, response_mode),
+    }
+    total = payload.get("count")
+    if isinstance(total, int):
+        out["total_available"] = total
+    return json.dumps(out, default=str)
+
+
+@mcp.tool()
+@_handle_errors
+def get_log(
+    log_id: int,
+    response_mode: ResponseMode = "full",
+) -> str:
+    """Get detail for a single official audit-log record."""
+    ws = _get_ws()
+    record = ws.log_detail(log_id)
+    if response_mode == "compact":
+        data = {k: record[k] for k in _DETAIL_COMPACT["log"] if k in record}
+    elif response_mode == "standard":
+        data = {k: record[k] for k in _DETAIL_STANDARD["log"] if k in record}
+    else:
+        data = record
+    return json.dumps({"data": data}, default=str)
+
+
+@mcp.tool()
+@_handle_errors
+def get_dashboard_history(
+    dashboard_id: int,
+    limit: int = 50,
+    include_local: bool = True,
+    response_mode: ResponseMode = "standard",
+    max_scan_pages: int = 5,
+) -> str:
+    """Return a dashboard-focused history view from official logs and local audit.
+
+    This tool first tries the official `/api/v1/log/` endpoint. If that route
+    is unavailable, it returns a capability note instead of failing. When
+    `include_local=True`, it also includes the MCP's local mutation journal and
+    pre-mutation dashboard snapshots.
+
+    Args:
+        dashboard_id: Dashboard ID to inspect.
+        limit: Maximum matching records to return per history source.
+        include_local: Include MCP-local mutation journal and snapshots.
+        response_mode: 'compact', 'standard', or 'full' for official log entries.
+        max_scan_pages: Max official log pages to scan before stopping.
+    """
+    if limit < 1 or limit > 100:
+        raise ValueError("limit must be between 1 and 100.")
+    if max_scan_pages < 1 or max_scan_pages > 20:
+        raise ValueError("max_scan_pages must be between 1 and 20.")
+
+    ws = _get_ws()
+    official: dict[str, Any] = {
+        "available": True,
+        "match_strategy": "best_effort dashboard-id + dashboard-token match",
+        "entries": [],
+        "scanned_pages": 0,
+        "scanned_records": 0,
+    }
+
+    page_size = min(100, max(limit, 25))
+    try:
+        matches: list[dict[str, Any]] = []
+        for page in range(max_scan_pages):
+            payload = ws.logs(page=page, page_size=page_size)
+            page_records = payload.get("result", [])
+            if not isinstance(page_records, list):
+                raise ValueError("List audit logs failed: malformed API response.")
+            official["scanned_pages"] = page + 1
+            official["scanned_records"] += len(page_records)
+            matches.extend(
+                record for record in page_records
+                if isinstance(record, dict) and _log_matches_dashboard(record, dashboard_id)
+            )
+            if len(matches) >= limit or not page_records:
+                break
+        official["entries"] = _format_log_records(matches[:limit], response_mode)
+        official["count"] = len(matches[:limit])
+    except ValueError as exc:
+        official = {
+            "available": False,
+            "error": str(exc),
+            "entries": [],
+            "count": 0,
+        }
+
+    out: dict[str, Any] = {
+        "dashboard_id": dashboard_id,
+        "official_logs": official,
+    }
+
+    if include_local:
+        mutations = _read_mutation_entries(
+            limit=limit,
+            resource_type="dashboard",
+            resource_id=dashboard_id,
+        )
+        snapshots = _list_dashboard_snapshot_records(dashboard_id, limit=limit)
+        out["local_history"] = {
+            "mutation_count": len(mutations),
+            "snapshot_count": len(snapshots),
+            "mutations": mutations if response_mode == "full" else _pick(
+                mutations,
+                ["timestamp", "tool_name", "action", "fields_changed", "dry_run"],
+            ),
+            "snapshots": snapshots,
+        }
+
+    return json.dumps(out, default=str)
 
 
 # ===================================================================
@@ -3777,35 +4045,7 @@ def list_dashboard_snapshots(
     if limit < 1 or limit > 500:
         raise ValueError("limit must be between 1 and 500.")
 
-    snap_dir = AUDIT_DIR / "snapshots"
-    if not snap_dir.exists():
-        return json.dumps({
-            "count": 0,
-            "dashboard_id": dashboard_id,
-            "snapshots": [],
-        }, default=str)
-
-    pattern = "dashboard_*.json" if dashboard_id is None else f"dashboard_{dashboard_id}_*.json"
-    files = sorted(
-        snap_dir.glob(pattern),
-        key=lambda path: path.stat().st_mtime,
-        reverse=True,
-    )
-    records: list[dict[str, Any]] = []
-    for snap in files[:limit]:
-        stem_parts = snap.stem.split("_")
-        snap_dashboard_id = _to_int(stem_parts[1]) if len(stem_parts) >= 3 else None
-        timestamp_token = stem_parts[2] if len(stem_parts) >= 3 else None
-        records.append({
-            "snapshot_path": str(snap),
-            "dashboard_id": snap_dashboard_id,
-            "timestamp_token": timestamp_token,
-            "size_bytes": snap.stat().st_size,
-            "modified_at": datetime.fromtimestamp(
-                snap.stat().st_mtime, tz=timezone.utc
-            ).isoformat(),
-        })
-
+    records = _list_dashboard_snapshot_records(dashboard_id, limit=limit)
     return json.dumps({
         "count": len(records),
         "dashboard_id": dashboard_id,

--- a/src/preset_py/workflow/__init__.py
+++ b/src/preset_py/workflow/__init__.py
@@ -1,0 +1,3 @@
+from preset_py.workflow.types import DashboardDocument
+
+__all__ = ["DashboardDocument"]

--- a/src/preset_py/workflow/document.py
+++ b/src/preset_py/workflow/document.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import yaml
 
+from preset_py.workflow.layout_ops import list_tab_ids
 from preset_py.workflow.types import DashboardDocument
 
 
@@ -10,14 +11,7 @@ def load_dashboard_yaml_document(path: Path) -> DashboardDocument:
     payload: dict[str, Any] = yaml.safe_load(path.read_text())
     position = payload.get("position") or {}
     metadata = payload.get("metadata") or {}
-    mode = (
-        "tabbed"
-        if any(
-            isinstance(node, dict) and node.get("type") == "TABS"
-            for node in position.values()
-        )
-        else "flat"
-    )
+    mode = "tabbed" if list_tab_ids(position) else "flat"
     return DashboardDocument(
         source_path=path,
         dashboard_title=str(payload.get("dashboard_title") or ""),

--- a/src/preset_py/workflow/document.py
+++ b/src/preset_py/workflow/document.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import yaml
 
-from preset_py.workflow.layout_ops import list_tab_ids
+from preset_py.workflow.layout_ops import has_tab_container
 from preset_py.workflow.types import DashboardDocument
 
 
@@ -11,7 +11,7 @@ def load_dashboard_yaml_document(path: Path) -> DashboardDocument:
     payload: dict[str, Any] = yaml.safe_load(path.read_text())
     position = payload.get("position") or {}
     metadata = payload.get("metadata") or {}
-    mode = "tabbed" if list_tab_ids(position) else "flat"
+    mode = "tabbed" if has_tab_container(position) else "flat"
     return DashboardDocument(
         source_path=path,
         dashboard_title=str(payload.get("dashboard_title") or ""),

--- a/src/preset_py/workflow/document.py
+++ b/src/preset_py/workflow/document.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from preset_py.workflow.types import DashboardDocument
+
+
+def load_dashboard_yaml_document(path: Path) -> DashboardDocument:
+    payload: dict[str, Any] = yaml.safe_load(path.read_text())
+    position = payload.get("position") or {}
+    metadata = payload.get("metadata") or {}
+    mode = (
+        "tabbed"
+        if any(
+            isinstance(node, dict) and node.get("type") == "TABS"
+            for node in position.values()
+        )
+        else "flat"
+    )
+    return DashboardDocument(
+        source_path=path,
+        dashboard_title=str(payload.get("dashboard_title") or ""),
+        mode=mode,
+        position=position,
+        metadata=metadata,
+    )

--- a/src/preset_py/workflow/layout_ops.py
+++ b/src/preset_py/workflow/layout_ops.py
@@ -2,6 +2,16 @@ from collections import defaultdict
 from typing import Any
 
 
+def _to_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value.strip())
+    return None
+
+
 def list_tab_ids(position: dict[str, Any]) -> list[str]:
     return sorted(
         node_id
@@ -15,8 +25,18 @@ def find_chart_node_ids(position: dict[str, Any]) -> dict[int, list[str]]:
     for node_id, node in position.items():
         if not isinstance(node, dict):
             continue
-        meta = node.get("meta") or {}
-        chart_id = meta.get("chartId")
-        if isinstance(chart_id, int):
+        chart_id = _to_int(node.get("chartId"))
+        if chart_id is None:
+            meta = node.get("meta")
+            if isinstance(meta, dict):
+                chart_id = _to_int(meta.get("chartId"))
+        if chart_id is not None:
             found[chart_id].append(node_id)
     return dict(found)
+
+
+def has_tab_container(position: dict[str, Any]) -> bool:
+    return any(
+        isinstance(node, dict) and node.get("type") == "TABS"
+        for node in position.values()
+    )

--- a/src/preset_py/workflow/layout_ops.py
+++ b/src/preset_py/workflow/layout_ops.py
@@ -1,0 +1,22 @@
+from collections import defaultdict
+from typing import Any
+
+
+def list_tab_ids(position: dict[str, Any]) -> list[str]:
+    return sorted(
+        node_id
+        for node_id, node in position.items()
+        if isinstance(node, dict) and node.get("type") == "TAB"
+    )
+
+
+def find_chart_node_ids(position: dict[str, Any]) -> dict[int, list[str]]:
+    found: dict[int, list[str]] = defaultdict(list)
+    for node_id, node in position.items():
+        if not isinstance(node, dict):
+            continue
+        meta = node.get("meta") or {}
+        chart_id = meta.get("chartId")
+        if isinstance(chart_id, int):
+            found[chart_id].append(node_id)
+    return dict(found)

--- a/src/preset_py/workflow/live_adapter.py
+++ b/src/preset_py/workflow/live_adapter.py
@@ -1,0 +1,21 @@
+import json
+from typing import Any
+
+from preset_py.workflow.presets import load_chart_preset
+
+
+def apply_live_chart_preset(
+    ws: Any,
+    *,
+    chart_id: int,
+    preset_name: str,
+) -> dict[str, Any]:
+    chart = ws.get_resource("chart", chart_id)
+    params = json.loads(chart.get("params") or "{}")
+    if not isinstance(params, dict):
+        raise ValueError(f"chart params must decode to a mapping for chart {chart_id}")
+
+    params.update(load_chart_preset(preset_name))
+    params.setdefault("datasource", f'{chart["datasource_id"]}__table')
+    params.setdefault("viz_type", chart["viz_type"])
+    return ws.update_chart(chart_id, params=json.dumps(params))

--- a/src/preset_py/workflow/planner.py
+++ b/src/preset_py/workflow/planner.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from typing import Any
+
+from preset_py.workflow.document import load_dashboard_yaml_document
+from preset_py.workflow.types import WorkflowPlan
+
+
+def plan_add_tab(*, yaml_path: Path, tab_name: str) -> dict[str, Any]:
+    document = load_dashboard_yaml_document(Path(yaml_path))
+    changes: list[dict[str, Any]] = []
+    summary = f"Plan add tab '{tab_name}' on {document.mode} dashboard"
+    if document.mode != "tabbed":
+        changes.append(
+            {"kind": "mode_transition", "from": document.mode, "to": "tabbed"}
+        )
+        summary = f"Plan add tab '{tab_name}' ({document.mode} -> tabbed)"
+    changes.append({"kind": "add_tab", "tab_name": tab_name})
+    plan = WorkflowPlan(
+        status="planned",
+        target={"mode": "yaml", "path": str(yaml_path)},
+        summary=summary,
+        changes=changes,
+    )
+    return plan.__dict__

--- a/src/preset_py/workflow/planner.py
+++ b/src/preset_py/workflow/planner.py
@@ -26,6 +26,30 @@ def plan_add_tab(*, yaml_path: Path, tab_name: str) -> dict[str, Any]:
     return plan.__dict__
 
 
+def plan_create_chart_with_preset(
+    *,
+    yaml_path: Path,
+    chart_title: str,
+    viz_type: str,
+    chart_preset: str,
+) -> dict[str, Any]:
+    document = load_dashboard_yaml_document(Path(yaml_path))
+    plan = WorkflowPlan(
+        status="planned",
+        target={"mode": "yaml", "path": str(yaml_path)},
+        summary=f"Plan create chart '{chart_title}' on {document.mode} dashboard",
+        changes=[
+            {
+                "kind": "create_chart",
+                "title": chart_title,
+                "viz_type": viz_type,
+                "chart_preset": chart_preset,
+            }
+        ],
+    )
+    return plan.__dict__
+
+
 def _tab_meta(text: str) -> dict[str, str]:
     return {
         "text": text,

--- a/src/preset_py/workflow/planner.py
+++ b/src/preset_py/workflow/planner.py
@@ -2,7 +2,9 @@ from pathlib import Path
 from typing import Any
 
 from preset_py.workflow.document import load_dashboard_yaml_document
+from preset_py.workflow.layout_ops import has_tab_container, list_tab_ids
 from preset_py.workflow.types import WorkflowPlan
+from preset_py.workflow.yaml_adapter import read_yaml_dashboard, write_yaml_dashboard
 
 
 def plan_add_tab(*, yaml_path: Path, tab_name: str) -> dict[str, Any]:
@@ -22,3 +24,148 @@ def plan_add_tab(*, yaml_path: Path, tab_name: str) -> dict[str, Any]:
         changes=changes,
     )
     return plan.__dict__
+
+
+def _tab_meta(text: str) -> dict[str, str]:
+    return {
+        "text": text,
+        "defaultText": "Tab title",
+        "placeholder": "Tab title",
+    }
+
+
+def _prepend_parents(
+    position: dict[str, Any],
+    *,
+    node_id: str,
+    root_id: str,
+    extra_parents: list[str],
+) -> None:
+    node = position.get(node_id)
+    if not isinstance(node, dict):
+        return
+
+    parents = node.get("parents")
+    if isinstance(parents, list):
+        cleaned = [str(parent) for parent in parents]
+        if cleaned and cleaned[0] == root_id:
+            node["parents"] = [root_id, *extra_parents, *cleaned[1:]]
+        else:
+            node["parents"] = [*extra_parents, *cleaned]
+
+    for child_id in node.get("children", []):
+        if isinstance(child_id, str):
+            _prepend_parents(
+                position,
+                node_id=child_id,
+                root_id=root_id,
+                extra_parents=extra_parents,
+            )
+
+
+def _apply_add_tab(position: dict[str, Any], tab_name: str) -> None:
+    root_id = "ROOT_ID"
+    root = position.get(root_id)
+    if not isinstance(root, dict):
+        raise ValueError("dashboard position is missing ROOT_ID")
+
+    if has_tab_container(position):
+        tabs_id = next(
+            node_id
+            for node_id, node in position.items()
+            if isinstance(node, dict) and node.get("type") == "TABS"
+        )
+        next_tab_number = len(list_tab_ids(position)) + 1
+        tab_id = f"TAB-{next_tab_number}"
+        grid_id = f"GRID-{next_tab_number}"
+        tabs_node = position[tabs_id]
+        tabs_node.setdefault("children", []).append(tab_id)
+        position[tab_id] = {
+            "id": tab_id,
+            "type": "TAB",
+            "parents": [root_id, tabs_id],
+            "children": [grid_id],
+            "meta": _tab_meta(tab_name),
+        }
+        position[grid_id] = {
+            "id": grid_id,
+            "type": "GRID",
+            "parents": [root_id, tabs_id, tab_id],
+            "children": [],
+        }
+        return
+
+    grid_id = next(
+        (
+            child_id
+            for child_id in root.get("children", [])
+            if isinstance(child_id, str)
+            and isinstance(position.get(child_id), dict)
+            and position[child_id].get("type") == "GRID"
+        ),
+        None,
+    )
+    if grid_id is None:
+        raise ValueError("flat dashboard must have a root grid before adding a tab")
+
+    tabs_id = "TABS_ID"
+    overview_tab_id = "TAB-1"
+    new_tab_id = "TAB-2"
+    new_grid_id = "GRID-2"
+
+    root["children"] = [tabs_id]
+    position[tabs_id] = {
+        "id": tabs_id,
+        "type": "TABS",
+        "parents": [root_id],
+        "children": [overview_tab_id, new_tab_id],
+    }
+    position[overview_tab_id] = {
+        "id": overview_tab_id,
+        "type": "TAB",
+        "parents": [root_id, tabs_id],
+        "children": [grid_id],
+        "meta": _tab_meta("Overview"),
+    }
+    position[new_tab_id] = {
+        "id": new_tab_id,
+        "type": "TAB",
+        "parents": [root_id, tabs_id],
+        "children": [new_grid_id],
+        "meta": _tab_meta(tab_name),
+    }
+    _prepend_parents(
+        position,
+        node_id=grid_id,
+        root_id=root_id,
+        extra_parents=[tabs_id, overview_tab_id],
+    )
+    position[new_grid_id] = {
+        "id": new_grid_id,
+        "type": "GRID",
+        "parents": [root_id, tabs_id, new_tab_id],
+        "children": [],
+    }
+
+
+def apply_workflow_plan(plan: dict[str, Any]) -> dict[str, Any]:
+    target = plan.get("target") or {}
+    if target.get("mode") != "yaml":
+        raise ValueError("only YAML workflow targets are supported")
+
+    path = Path(str(target["path"]))
+    payload = read_yaml_dashboard(path)
+    position = payload.setdefault("position", {})
+    if not isinstance(position, dict):
+        raise ValueError("dashboard position must be a mapping")
+
+    for change in plan.get("changes", []):
+        if change.get("kind") == "add_tab":
+            _apply_add_tab(position, str(change["tab_name"]))
+
+    write_yaml_dashboard(path, payload)
+    return {
+        "status": "applied",
+        "target": target,
+        "applied_changes": plan.get("changes", []),
+    }

--- a/src/preset_py/workflow/presets.py
+++ b/src/preset_py/workflow/presets.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+_PRESET_ROOT = Path(__file__).resolve().parent.parent / "presets"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text())
+    assert isinstance(payload, dict)
+    return payload
+
+
+def load_layout_preset(name: str) -> dict[str, Any]:
+    return _load_yaml(_PRESET_ROOT / "layouts" / f"{name}.yaml")
+
+
+def load_chart_preset(name: str) -> dict[str, Any]:
+    return _load_yaml(_PRESET_ROOT / "charts" / f"{name}.yaml")

--- a/src/preset_py/workflow/presets.py
+++ b/src/preset_py/workflow/presets.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 from typing import Any
 
@@ -5,17 +6,27 @@ import yaml
 
 
 _PRESET_ROOT = Path(__file__).resolve().parent.parent / "presets"
+_PRESET_NAME_RE = re.compile(r"^[a-z0-9_]+$")
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
-    payload = yaml.safe_load(path.read_text())
-    assert isinstance(payload, dict)
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"preset file must contain a mapping: {path}")
     return payload
 
 
+def _validate_preset_name(name: str) -> str:
+    if not _PRESET_NAME_RE.fullmatch(name):
+        raise ValueError(f"invalid preset name: {name}")
+    return name
+
+
 def load_layout_preset(name: str) -> dict[str, Any]:
+    name = _validate_preset_name(name)
     return _load_yaml(_PRESET_ROOT / "layouts" / f"{name}.yaml")
 
 
 def load_chart_preset(name: str) -> dict[str, Any]:
+    name = _validate_preset_name(name)
     return _load_yaml(_PRESET_ROOT / "charts" / f"{name}.yaml")

--- a/src/preset_py/workflow/types.py
+++ b/src/preset_py/workflow/types.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -10,3 +10,12 @@ class DashboardDocument:
     mode: str
     position: dict[str, Any]
     metadata: dict[str, Any]
+
+
+@dataclass
+class WorkflowPlan:
+    status: str
+    target: dict[str, Any]
+    summary: str
+    changes: list[dict[str, Any]] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)

--- a/src/preset_py/workflow/types.py
+++ b/src/preset_py/workflow/types.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class DashboardDocument:
+    source_path: Path
+    dashboard_title: str
+    mode: str
+    position: dict[str, Any]
+    metadata: dict[str, Any]

--- a/src/preset_py/workflow/yaml_adapter.py
+++ b/src/preset_py/workflow/yaml_adapter.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def read_yaml_dashboard(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"dashboard YAML must contain a mapping: {path}")
+    return payload
+
+
+def write_yaml_dashboard(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")

--- a/tests/fixtures/workflow/research_yield_simple.yaml
+++ b/tests/fixtures/workflow/research_yield_simple.yaml
@@ -1,0 +1,25 @@
+dashboard_title: "[Research] Yield Simple"
+position:
+  ROOT_ID:
+    id: ROOT_ID
+    type: ROOT
+    children: [GRID_ID]
+  GRID_ID:
+    id: GRID_ID
+    type: GRID
+    parents: [ROOT_ID]
+    children: [ROW-1]
+  ROW-1:
+    id: ROW-1
+    type: ROW
+    parents: [ROOT_ID, GRID_ID]
+    children: [CHART-1384]
+  CHART-1384:
+    id: CHART-1384
+    type: CHART
+    parents: [ROOT_ID, GRID_ID, ROW-1]
+    children: []
+    meta:
+      chartId: 1384
+      sliceName: USDC Supplier Yield Share (Annualized, Active)
+metadata: {}

--- a/tests/fixtures/workflow/tabbed_dashboard.yaml
+++ b/tests/fixtures/workflow/tabbed_dashboard.yaml
@@ -1,0 +1,22 @@
+dashboard_title: "[Research] Tabbed Dashboard"
+position:
+  ROOT_ID:
+    id: ROOT_ID
+    type: ROOT
+    children: [TABS_ID]
+  TABS_ID:
+    id: TABS_ID
+    type: TABS
+    parents: [ROOT_ID]
+    children: [TAB-1]
+  TAB-1:
+    id: TAB-1
+    type: TAB
+    parents: [ROOT_ID, TABS_ID]
+    children: [GRID_ID]
+  GRID_ID:
+    id: GRID_ID
+    type: GRID
+    parents: [ROOT_ID, TABS_ID, TAB-1]
+    children: []
+metadata: {}

--- a/tests/test_new_tools.py
+++ b/tests/test_new_tools.py
@@ -33,6 +33,130 @@ class _WorkspaceBase:
 
 
 # ===================================================================
+# Official Audit Logs
+# ===================================================================
+
+_LOG_RECORDS = [
+    {
+        "id": 10,
+        "action": "dashboard.update",
+        "dttm": "2026-03-10T14:48:33Z",
+        "user_id": 75,
+        "dashboard_id": 170,
+        "path": "/api/v1/dashboard/170",
+    },
+    {
+        "id": 11,
+        "action": "chart.update",
+        "dttm": "2026-03-10T15:00:00Z",
+        "user_id": 75,
+        "slice_id": 1392,
+        "path": "/api/v1/chart/1392",
+    },
+]
+
+
+class _LogsWS(_WorkspaceBase):
+    def logs(self, *, page: int = 0, page_size: int = 50, **kwargs):
+        assert page_size == 50
+        records = list(_LOG_RECORDS) if page == 0 else []
+        return {"count": len(_LOG_RECORDS), "result": records}
+
+    def log_detail(self, log_id: int):
+        for record in _LOG_RECORDS:
+            if record["id"] == log_id:
+                return dict(record)
+        raise ValueError(f"not found: {log_id}")
+
+
+class _LogsUnavailableWS(_WorkspaceBase):
+    def logs(self, **kwargs):
+        raise ValueError(
+            "List audit logs failed: the official audit-log endpoint is unavailable "
+            "in this Preset/Superset deployment or for the current role."
+        )
+
+    def log_detail(self, log_id: int):
+        raise ValueError("unavailable")
+
+
+def test_list_logs_standard(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _LogsWS())
+    raw = server.list_logs.fn(response_mode="standard")
+    payload = json.loads(raw)
+    assert payload["count"] == 2
+    first = payload["data"][0]
+    assert first["id"] == 10
+    assert first["action"] == "dashboard.update"
+
+
+def test_list_logs_dashboard_filter(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _LogsWS())
+    raw = server.list_logs.fn(dashboard_id=170)
+    payload = json.loads(raw)
+    assert payload["count"] == 1
+    assert payload["data"][0]["id"] == 10
+
+
+def test_get_log_compact(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _LogsWS())
+    raw = server.get_log.fn(log_id=10, response_mode="compact")
+    payload = json.loads(raw)
+    assert payload["data"] == {
+        "id": 10,
+        "action": "dashboard.update",
+        "dttm": "2026-03-10T14:48:33Z",
+    }
+
+
+def test_get_dashboard_history_combines_official_and_local(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _LogsWS())
+    monkeypatch.setattr(
+        server,
+        "_read_mutation_entries",
+        lambda **kwargs: [{
+            "timestamp": "2026-03-10T14:48:33Z",
+            "tool_name": "update_dashboard",
+            "action": "update",
+            "fields_changed": ["position_json"],
+            "dry_run": False,
+        }],
+    )
+    monkeypatch.setattr(
+        server,
+        "_list_dashboard_snapshot_records",
+        lambda dashboard_id, limit: [{
+            "snapshot_path": "/tmp/dashboard_170.json",
+            "dashboard_id": dashboard_id,
+            "timestamp_token": "20260310T144832Z",
+            "size_bytes": 123,
+            "modified_at": "2026-03-10T14:48:32Z",
+        }],
+    )
+
+    raw = server.get_dashboard_history.fn(dashboard_id=170)
+    payload = json.loads(raw)
+    assert payload["official_logs"]["available"] is True
+    assert payload["official_logs"]["count"] == 1
+    assert payload["local_history"]["mutation_count"] == 1
+    assert payload["local_history"]["snapshot_count"] == 1
+
+
+def test_get_dashboard_history_handles_missing_official_logs(monkeypatch) -> None:
+    monkeypatch.setattr(server, "_get_ws", lambda: _LogsUnavailableWS())
+    monkeypatch.setattr(server, "_read_mutation_entries", lambda **kwargs: [])
+    monkeypatch.setattr(
+        server, "_list_dashboard_snapshot_records", lambda dashboard_id, limit: []
+    )
+
+    raw = server.get_dashboard_history.fn(dashboard_id=170)
+    payload = json.loads(raw)
+    assert payload["official_logs"]["available"] is False
+    assert payload["official_logs"]["count"] == 0
+    assert payload["local_history"]["mutation_count"] == 0
+
+
+# ===================================================================
 # Saved Queries
 # ===================================================================
 

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -48,37 +48,6 @@ def test_create_dataset_checks_database_precondition(monkeypatch) -> None:
     assert "Database 999 not found" in payload["error"]
 
 
-def test_plan_dashboard_changes_supports_yaml_target(tmp_path) -> None:
-    dashboard = tmp_path / "dashboard.yaml"
-    dashboard.write_text("dashboard_title: demo\nposition: {}\nmetadata: {}\n")
-
-    raw = server.plan_dashboard_changes.fn(
-        yaml_path=str(dashboard),
-        operations='[{"kind":"add_tab","tab_name":"Sandbox"}]',
-    )
-
-    payload = json.loads(raw)
-    assert payload["status"] == "planned"
-    assert payload["target"]["mode"] == "yaml"
-
-
-def test_apply_dashboard_plan_supports_yaml_target(tmp_path) -> None:
-    dashboard = tmp_path / "dashboard.yaml"
-    dashboard.write_text(
-        "dashboard_title: demo\nposition:\n  ROOT_ID:\n    id: ROOT_ID\n    type: ROOT\n    children: [GRID_ID]\n  GRID_ID:\n    id: GRID_ID\n    type: GRID\n    parents: [ROOT_ID]\n    children: []\nmetadata: {}\n"
-    )
-
-    plan_json = server.plan_dashboard_changes.fn(
-        yaml_path=str(dashboard),
-        operations='[{"kind":"add_tab","tab_name":"Sandbox"}]',
-    )
-    raw = server.apply_dashboard_plan.fn(plan_json=plan_json)
-
-    payload = json.loads(raw)
-    assert payload["status"] == "applied"
-    assert "text: Sandbox" in dashboard.read_text()
-
-
 def test_query_dataset_treats_time_column_as_timeseries(monkeypatch) -> None:
     class _WS(_WorkspaceBase):
         def __init__(self) -> None:

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -45,6 +46,37 @@ def test_create_dataset_checks_database_precondition(monkeypatch) -> None:
         )
     payload = _validation_payload(exc.value)
     assert "Database 999 not found" in payload["error"]
+
+
+def test_plan_dashboard_changes_supports_yaml_target(tmp_path) -> None:
+    dashboard = tmp_path / "dashboard.yaml"
+    dashboard.write_text("dashboard_title: demo\nposition: {}\nmetadata: {}\n")
+
+    raw = server.plan_dashboard_changes.fn(
+        yaml_path=str(dashboard),
+        operations='[{"kind":"add_tab","tab_name":"Sandbox"}]',
+    )
+
+    payload = json.loads(raw)
+    assert payload["status"] == "planned"
+    assert payload["target"]["mode"] == "yaml"
+
+
+def test_apply_dashboard_plan_supports_yaml_target(tmp_path) -> None:
+    dashboard = tmp_path / "dashboard.yaml"
+    dashboard.write_text(
+        "dashboard_title: demo\nposition:\n  ROOT_ID:\n    id: ROOT_ID\n    type: ROOT\n    children: [GRID_ID]\n  GRID_ID:\n    id: GRID_ID\n    type: GRID\n    parents: [ROOT_ID]\n    children: []\nmetadata: {}\n"
+    )
+
+    plan_json = server.plan_dashboard_changes.fn(
+        yaml_path=str(dashboard),
+        operations='[{"kind":"add_tab","tab_name":"Sandbox"}]',
+    )
+    raw = server.apply_dashboard_plan.fn(plan_json=plan_json)
+
+    payload = json.loads(raw)
+    assert payload["status"] == "applied"
+    assert "text: Sandbox" in dashboard.read_text()
 
 
 def test_query_dataset_treats_time_column_as_timeseries(monkeypatch) -> None:
@@ -1571,3 +1603,39 @@ def test_update_chart_returns_result_on_validation_timeout(monkeypatch) -> None:
     assert payload["_validation"]["status"] == "timeout"
     assert payload["_validation"]["error_type"] == "TimeoutError"
     assert "updated successfully" in payload["_validation"]["error"]
+
+
+def test_plan_dashboard_changes_supports_yaml_target(tmp_path: Path) -> None:
+    dashboard = tmp_path / "dashboard.yaml"
+    dashboard.write_text("dashboard_title: demo\nposition: {}\nmetadata: {}\n")
+
+    raw = server.plan_dashboard_changes.fn(
+        yaml_path=str(dashboard),
+        operations='[{"kind":"add_tab","tab_name":"Sandbox"}]',
+    )
+
+    payload = json.loads(raw)
+    assert payload["status"] == "planned"
+    assert payload["target"]["mode"] == "yaml"
+
+
+def test_apply_dashboard_plan_supports_yaml_target(tmp_path: Path) -> None:
+    dashboard = tmp_path / "dashboard.yaml"
+    fixture = Path("tests/fixtures/workflow/research_yield_simple.yaml")
+    dashboard.write_text(fixture.read_text(encoding="utf-8"), encoding="utf-8")
+
+    plan = {
+        "status": "planned",
+        "target": {"mode": "yaml", "path": str(dashboard)},
+        "summary": "Plan add tab 'Sandbox' (flat -> tabbed)",
+        "changes": [
+            {"kind": "mode_transition", "from": "flat", "to": "tabbed"},
+            {"kind": "add_tab", "tab_name": "Sandbox"},
+        ],
+    }
+
+    raw = server.apply_dashboard_plan.fn(plan_json=json.dumps(plan))
+
+    payload = json.loads(raw)
+    assert payload["status"] == "applied"
+    assert "type: TABS" in dashboard.read_text(encoding="utf-8")

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -48,6 +48,37 @@ def test_create_dataset_checks_database_precondition(monkeypatch) -> None:
     assert "Database 999 not found" in payload["error"]
 
 
+def test_plan_dashboard_changes_supports_yaml_target(tmp_path) -> None:
+    dashboard = tmp_path / "dashboard.yaml"
+    dashboard.write_text("dashboard_title: demo\nposition: {}\nmetadata: {}\n")
+
+    raw = server.plan_dashboard_changes.fn(
+        yaml_path=str(dashboard),
+        operations='[{"kind":"add_tab","tab_name":"Sandbox"}]',
+    )
+
+    payload = json.loads(raw)
+    assert payload["status"] == "planned"
+    assert payload["target"]["mode"] == "yaml"
+
+
+def test_apply_dashboard_plan_supports_yaml_target(tmp_path) -> None:
+    dashboard = tmp_path / "dashboard.yaml"
+    dashboard.write_text(
+        "dashboard_title: demo\nposition:\n  ROOT_ID:\n    id: ROOT_ID\n    type: ROOT\n    children: [GRID_ID]\n  GRID_ID:\n    id: GRID_ID\n    type: GRID\n    parents: [ROOT_ID]\n    children: []\nmetadata: {}\n"
+    )
+
+    plan_json = server.plan_dashboard_changes.fn(
+        yaml_path=str(dashboard),
+        operations='[{"kind":"add_tab","tab_name":"Sandbox"}]',
+    )
+    raw = server.apply_dashboard_plan.fn(plan_json=plan_json)
+
+    payload = json.loads(raw)
+    assert payload["status"] == "applied"
+    assert "text: Sandbox" in dashboard.read_text()
+
+
 def test_query_dataset_treats_time_column_as_timeseries(monkeypatch) -> None:
     class _WS(_WorkspaceBase):
         def __init__(self) -> None:

--- a/tests/test_workflow_live.py
+++ b/tests/test_workflow_live.py
@@ -1,0 +1,39 @@
+from preset_py.workflow.live_adapter import apply_live_chart_preset
+
+
+class _WS:
+    def __init__(self) -> None:
+        self.updated = None
+
+    def chart_detail(self, chart_id: int) -> dict:
+        return {
+            "id": chart_id,
+            "viz_type": "echarts_timeseries_line",
+            "datasource_id": 10,
+            "params": '{"datasource":"10__table","viz_type":"echarts_timeseries_line","metrics":["count"],"groupby":["CHAIN"]}',
+        }
+
+    def get_resource(self, resource_type: str, resource_id: int) -> dict:
+        assert resource_type == "chart"
+        return self.chart_detail(resource_id)
+
+    def dataset_detail(self, dataset_id: int) -> dict:
+        return {
+            "id": dataset_id,
+            "columns": [{"column_name": "CHAIN"}],
+            "metrics": [{"metric_name": "count"}],
+        }
+
+    def update_chart(self, chart_id: int, **kwargs) -> dict:
+        self.updated = kwargs
+        return {"id": chart_id, **kwargs}
+
+
+def test_apply_live_chart_preset_compiles_to_update_chart() -> None:
+    ws = _WS()
+
+    result = apply_live_chart_preset(ws, chart_id=5, preset_name="timeseries_default")
+
+    assert result["id"] == 5
+    assert ws.updated is not None
+    assert '"x_axis_title_margin": 30' in ws.updated["params"]

--- a/tests/test_workflow_yaml.py
+++ b/tests/test_workflow_yaml.py
@@ -4,7 +4,7 @@ import pytest
 
 from preset_py.workflow.document import load_dashboard_yaml_document
 from preset_py.workflow.layout_ops import find_chart_node_ids, list_tab_ids
-from preset_py.workflow.planner import plan_add_tab
+from preset_py.workflow.planner import apply_workflow_plan, plan_add_tab
 from preset_py.workflow.presets import load_chart_preset, load_layout_preset
 
 
@@ -118,6 +118,20 @@ def test_plan_add_tab_on_tabbed_dashboard_avoids_fake_mode_transition() -> None:
     assert plan["status"] == "planned"
     assert not any(change["kind"] == "mode_transition" for change in plan["changes"])
     assert plan["changes"] == [{"kind": "add_tab", "tab_name": "Sandbox"}]
+
+
+def test_apply_workflow_plan_writes_tabbed_yaml(tmp_path: Path) -> None:
+    target = tmp_path / "dashboard.yaml"
+    fixture = Path("tests/fixtures/workflow/research_yield_simple.yaml")
+    target.write_text(fixture.read_text(encoding="utf-8"), encoding="utf-8")
+
+    plan = plan_add_tab(yaml_path=target, tab_name="Sandbox")
+    result = apply_workflow_plan(plan)
+
+    assert result["status"] == "applied"
+    written = target.read_text(encoding="utf-8")
+    assert "type: TABS" in written
+    assert "text: Sandbox" in written
 
 
 def test_load_layout_preset_rejects_invalid_name() -> None:

--- a/tests/test_workflow_yaml.py
+++ b/tests/test_workflow_yaml.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from preset_py.workflow.document import load_dashboard_yaml_document
+
+
+def test_load_dashboard_yaml_document_reads_flat_fixture() -> None:
+    fixture = Path("tests/fixtures/workflow/research_yield_simple.yaml")
+
+    document = load_dashboard_yaml_document(fixture)
+
+    assert document.dashboard_title == "[Research] Yield Simple"
+    assert document.mode == "flat"
+    assert "ROOT_ID" in document.position

--- a/tests/test_workflow_yaml.py
+++ b/tests/test_workflow_yaml.py
@@ -99,6 +99,7 @@ def test_load_chart_preset_reads_timeseries_defaults() -> None:
 
 def test_plan_add_tab_returns_structural_change_without_mutating_file() -> None:
     fixture = Path("tests/fixtures/workflow/research_yield_simple.yaml")
+    original = fixture.read_text(encoding="utf-8")
 
     plan = plan_add_tab(yaml_path=fixture, tab_name="Sandbox")
 
@@ -106,6 +107,17 @@ def test_plan_add_tab_returns_structural_change_without_mutating_file() -> None:
     assert plan["target"]["mode"] == "yaml"
     assert any(change["kind"] == "mode_transition" for change in plan["changes"])
     assert "flat" in plan["summary"]
+    assert fixture.read_text(encoding="utf-8") == original
+
+
+def test_plan_add_tab_on_tabbed_dashboard_avoids_fake_mode_transition() -> None:
+    fixture = Path("tests/fixtures/workflow/tabbed_dashboard.yaml")
+
+    plan = plan_add_tab(yaml_path=fixture, tab_name="Sandbox")
+
+    assert plan["status"] == "planned"
+    assert not any(change["kind"] == "mode_transition" for change in plan["changes"])
+    assert plan["changes"] == [{"kind": "add_tab", "tab_name": "Sandbox"}]
 
 
 def test_load_layout_preset_rejects_invalid_name() -> None:

--- a/tests/test_workflow_yaml.py
+++ b/tests/test_workflow_yaml.py
@@ -24,6 +24,32 @@ def test_load_dashboard_yaml_document_reads_tabbed_fixture() -> None:
     assert "TABS_ID" in document.position
 
 
+def test_load_dashboard_yaml_document_marks_empty_tabs_container_as_tabbed(
+    tmp_path: Path,
+) -> None:
+    fixture = tmp_path / "authoring_tabbed.yaml"
+    fixture.write_text(
+        """
+dashboard_title: "[Research] Empty Tabs Dashboard"
+position:
+  ROOT_ID:
+    id: ROOT_ID
+    type: ROOT
+    children: [TABS_ID]
+  TABS_ID:
+    id: TABS_ID
+    type: TABS
+    parents: [ROOT_ID]
+    children: []
+metadata: {}
+""".strip()
+    )
+
+    document = load_dashboard_yaml_document(fixture)
+
+    assert document.mode == "tabbed"
+
+
 def test_list_tab_ids_returns_empty_for_flat_dashboard() -> None:
     document = load_dashboard_yaml_document(
         Path("tests/fixtures/workflow/research_yield_simple.yaml")
@@ -38,3 +64,16 @@ def test_find_chart_node_ids_returns_chart_nodes() -> None:
     )
 
     assert find_chart_node_ids(document.position) == {1384: ["CHART-1384"]}
+
+
+def test_find_chart_node_ids_recognizes_top_level_chart_id() -> None:
+    position = {
+        "CHART-1": {
+            "id": "CHART-1",
+            "type": "CHART",
+            "chartId": 101,
+            "children": [],
+        }
+    }
+
+    assert find_chart_node_ids(position) == {101: ["CHART-1"]}

--- a/tests/test_workflow_yaml.py
+++ b/tests/test_workflow_yaml.py
@@ -99,6 +99,23 @@ def test_load_chart_preset_reads_timeseries_defaults() -> None:
 
     assert preset["x_axis_title_margin"] == 30
     assert preset["y_axis_title_margin"] == 50
+    assert preset["legend_orientation"] == "top"
+
+
+def test_load_chart_preset_reads_pie_defaults() -> None:
+    preset = load_chart_preset("pie_default")
+
+    assert preset["legend_orientation"] == "top"
+    assert preset["labels_outside"] is True
+    assert preset["number_format"] == "SMART_NUMBER"
+
+
+def test_load_chart_preset_reads_table_defaults() -> None:
+    preset = load_chart_preset("table_default")
+
+    assert preset["row_limit"] == 1000
+    assert preset["order_by_cols"] == []
+    assert preset["order_desc"] is True
 
 
 def test_plan_add_tab_returns_structural_change_without_mutating_file() -> None:

--- a/tests/test_workflow_yaml.py
+++ b/tests/test_workflow_yaml.py
@@ -11,3 +11,13 @@ def test_load_dashboard_yaml_document_reads_flat_fixture() -> None:
     assert document.dashboard_title == "[Research] Yield Simple"
     assert document.mode == "flat"
     assert "ROOT_ID" in document.position
+
+
+def test_load_dashboard_yaml_document_reads_tabbed_fixture() -> None:
+    fixture = Path("tests/fixtures/workflow/tabbed_dashboard.yaml")
+
+    document = load_dashboard_yaml_document(fixture)
+
+    assert document.dashboard_title == "[Research] Tabbed Dashboard"
+    assert document.mode == "tabbed"
+    assert "TABS_ID" in document.position

--- a/tests/test_workflow_yaml.py
+++ b/tests/test_workflow_yaml.py
@@ -1,7 +1,10 @@
 from pathlib import Path
 
+import pytest
+
 from preset_py.workflow.document import load_dashboard_yaml_document
 from preset_py.workflow.layout_ops import find_chart_node_ids, list_tab_ids
+from preset_py.workflow.planner import plan_add_tab
 from preset_py.workflow.presets import load_chart_preset, load_layout_preset
 
 
@@ -92,3 +95,30 @@ def test_load_chart_preset_reads_timeseries_defaults() -> None:
 
     assert preset["x_axis_title_margin"] == 30
     assert preset["y_axis_title_margin"] == 50
+
+
+def test_plan_add_tab_returns_structural_change_without_mutating_file() -> None:
+    fixture = Path("tests/fixtures/workflow/research_yield_simple.yaml")
+
+    plan = plan_add_tab(yaml_path=fixture, tab_name="Sandbox")
+
+    assert plan["status"] == "planned"
+    assert plan["target"]["mode"] == "yaml"
+    assert any(change["kind"] == "mode_transition" for change in plan["changes"])
+    assert "flat" in plan["summary"]
+
+
+def test_load_layout_preset_rejects_invalid_name() -> None:
+    with pytest.raises(ValueError, match="invalid preset name"):
+        load_layout_preset("../secrets")
+
+
+def test_load_chart_preset_requires_mapping_payload(tmp_path: Path, monkeypatch) -> None:
+    preset_root = tmp_path / "presets"
+    (preset_root / "charts").mkdir(parents=True)
+    (preset_root / "charts" / "broken.yaml").write_text("- not-a-mapping\n", encoding="utf-8")
+
+    monkeypatch.setattr("preset_py.workflow.presets._PRESET_ROOT", preset_root)
+
+    with pytest.raises(ValueError, match="must contain a mapping"):
+        load_chart_preset("broken")

--- a/tests/test_workflow_yaml.py
+++ b/tests/test_workflow_yaml.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from preset_py.workflow.document import load_dashboard_yaml_document
 from preset_py.workflow.layout_ops import find_chart_node_ids, list_tab_ids
+from preset_py.workflow.presets import load_chart_preset, load_layout_preset
 
 
 def test_load_dashboard_yaml_document_reads_flat_fixture() -> None:
@@ -77,3 +78,17 @@ def test_find_chart_node_ids_recognizes_top_level_chart_id() -> None:
     }
 
     assert find_chart_node_ids(position) == {101: ["CHART-1"]}
+
+
+def test_load_layout_preset_reads_flat_two_up() -> None:
+    preset = load_layout_preset("flat_two_up")
+
+    assert preset["mode"] == "flat"
+    assert preset["charts_per_row"] == 2
+
+
+def test_load_chart_preset_reads_timeseries_defaults() -> None:
+    preset = load_chart_preset("timeseries_default")
+
+    assert preset["x_axis_title_margin"] == 30
+    assert preset["y_axis_title_margin"] == 50

--- a/tests/test_workflow_yaml.py
+++ b/tests/test_workflow_yaml.py
@@ -4,7 +4,11 @@ import pytest
 
 from preset_py.workflow.document import load_dashboard_yaml_document
 from preset_py.workflow.layout_ops import find_chart_node_ids, list_tab_ids
-from preset_py.workflow.planner import apply_workflow_plan, plan_add_tab
+from preset_py.workflow.planner import (
+    apply_workflow_plan,
+    plan_add_tab,
+    plan_create_chart_with_preset,
+)
 from preset_py.workflow.presets import load_chart_preset, load_layout_preset
 
 
@@ -132,6 +136,21 @@ def test_apply_workflow_plan_writes_tabbed_yaml(tmp_path: Path) -> None:
     written = target.read_text(encoding="utf-8")
     assert "type: TABS" in written
     assert "text: Sandbox" in written
+
+
+def test_plan_create_chart_with_preset_keeps_flat_dashboard_flat(tmp_path: Path) -> None:
+    target = tmp_path / "dashboard.yaml"
+    fixture = Path("tests/fixtures/workflow/research_yield_simple.yaml")
+    target.write_text(fixture.read_text(encoding="utf-8"), encoding="utf-8")
+
+    plan = plan_create_chart_with_preset(
+        yaml_path=target,
+        chart_title="New Chart",
+        viz_type="table",
+        chart_preset="table_default",
+    )
+
+    assert not any(change["kind"] == "mode_transition" for change in plan["changes"])
 
 
 def test_load_layout_preset_rejects_invalid_name() -> None:

--- a/tests/test_workflow_yaml.py
+++ b/tests/test_workflow_yaml.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from preset_py.workflow.document import load_dashboard_yaml_document
+from preset_py.workflow.layout_ops import find_chart_node_ids, list_tab_ids
 
 
 def test_load_dashboard_yaml_document_reads_flat_fixture() -> None:
@@ -21,3 +22,19 @@ def test_load_dashboard_yaml_document_reads_tabbed_fixture() -> None:
     assert document.dashboard_title == "[Research] Tabbed Dashboard"
     assert document.mode == "tabbed"
     assert "TABS_ID" in document.position
+
+
+def test_list_tab_ids_returns_empty_for_flat_dashboard() -> None:
+    document = load_dashboard_yaml_document(
+        Path("tests/fixtures/workflow/research_yield_simple.yaml")
+    )
+
+    assert list_tab_ids(document.position) == []
+
+
+def test_find_chart_node_ids_returns_chart_nodes() -> None:
+    document = load_dashboard_yaml_document(
+        Path("tests/fixtures/workflow/research_yield_simple.yaml")
+    )
+
+    assert find_chart_node_ids(document.position) == {1384: ["CHART-1384"]}


### PR DESCRIPTION
## Summary
- add official audit-log and dashboard history tooling for Preset/Superset environments that expose `/api/v1/log/`
- add a YAML-first, additive workflow layer with plan/apply helpers, offline YAML apply, live chart-preset compilation, and workflow MCP tools
- add docs and regression coverage for the new workflow surfaces and align starter presets with the written design

## Why
This branch improves both observability and authoring ergonomics in `preset-mcp` without replacing the existing low-level tools. It adds best-effort history/audit support where the upstream deployment exposes it, and it adds a safer plan-first workflow layer for local YAML and targeted live mutations.

## Impact
Users can inspect official logs and dashboard history when available, and they can also use the new workflow plan/apply path for YAML-first dashboard authoring while keeping flat dashboards first-class.

## Test Plan
- `uv run pytest tests/test_workflow_yaml.py -q`
- `uv run pytest tests/test_workflow_yaml.py tests/test_workflow_live.py tests/test_server_tools.py -q`
